### PR TITLE
fix block weight item for supporting bitcoin-abc

### DIFF
--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -56,7 +56,8 @@ div(class="tab-content")
 				th(class="table-active properties-header") Size
 				td(class="monospace")
 					span #{result.getblock.size.toLocaleString()} bytes
-					span(class="text-muted")  (weight: #{result.getblock.weight.toLocaleString()})
+					if (result.getblock.weight)
+						span(class="text-muted")  (weight: #{result.getblock.weight.toLocaleString()})
 
 			tr
 				th(class="table-active properties-header") Confirmations


### PR DESCRIPTION
bitcoin-abc is a fork from bitcoin-core. Now bitcoin-abc has remove weight item from the rpc command(bitcoin-cli getblock blockhash). This modification will be friendly to support bitcoin-abc(BCH).

The difference is:

```
# bitcoin-core
bitcoin/src$ bitcoin-cli getblock 00000000000000000019afc3cf0f12414c3b03cc36b10964922d86d7c7cd8498
{
  "hash": "00000000000000000019afc3cf0f12414c3b03cc36b10964922d86d7c7cd8498",
  "confirmations": 1,
  "strippedsize": 50447,
  "size": 66460,
  "weight": 217801,
  "height": 515053,
  "version": 536870912,
  "versionHex": "20000000",
  "merkleroot": "87d24c7880ce75eea74be50b0fbccbeb3d25eeb0d7b84996a412168c2b2a894e",
  "tx": [
    "34a42eb61a7f0685de8db7784a541bf4d5a88fa60d5edcba0112b10ca4b0cc6f",
    "94741527a643eab80266e52a745e53217596c36184240c41a0f374f8850c34e9",
    "e3b2e7215615634907a350d76b112a8b37bef7ad62126f5badcf03d43912826a",
    "10eab520ac6a651d16a72aad854b8358ccd18b5ee304e55e4b53279c366d7e27",
    "..."

# bitcoin-abc
bitcoin-abc/src# bitcoin-cli getblock 000000000000011cbbeca50668c65778b20687c1b3559838467b6faf4ec02a74
{
  "hash": "000000000000011cbbeca50668c65778b20687c1b3559838467b6faf4ec02a74",
  "confirmations": 1,
  "size": 211,
  "height": 1220248,
  "version": 536870914,
  "versionHex": "20000002",
  "merkleroot": "1f5d2182cee19b41a718e6a2b9c0680d5c05dfc47f65cda11ccee5fc57a04901",
  "tx": [
    "1f5d2182cee19b41a718e6a2b9c0680d5c05dfc47f65cda11ccee5fc57a04901"
  ],
```