### PR TITLE
Argument type fix

### DIFF
--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -569,7 +569,7 @@ router.get("/rpc-browser", function(req, res) {
 							var argProperties = argDetails[i].properties;
 
 							for (var j = 0; j < argProperties.length; j++) {
-								if (argProperties[j] == "numeric") {
+								if (argProperties[j] === "numeric") {
 									if (req.query.args[i] == null || req.query.args[i] == "") {
 										argValues.push(null);
 
@@ -579,19 +579,22 @@ router.get("/rpc-browser", function(req, res) {
 
 									break;
 
-								} else if (argProperties[j] == "boolean") {
+								} else if (argProperties[j] === "boolean") {
 									if (req.query.args[i]) {
 										argValues.push(req.query.args[i] == "true");
 									}
 
 									break;
 
-								} else if (argProperties[j] == "string") {
+								} else if (argProperties[j] === "string" || argProperties[j] === "numeric or string") {
 									if (req.query.args[i]) {
 										argValues.push(req.query.args[i]);
 									}
 
 									break;
+								}
+								else {
+								  console.log(`Unknown argument property: ${argProperties[j]}`);
 								}
 							}
 						}


### PR DESCRIPTION
Fixes sendtoaddress RCP call. Currently specifying amount argument gets lost from request: 
```
Executing RPC 'sendtoaddress' with params: [sgbfXLGi3VJnvKKu7ZMpMCZQvEiPRTSDox,]
RPC Response: err=null, result=RpcError: -3 Amount is not a number or string, headers=undefined
```