### PR TITLE
Store params in environment variables and avoid file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,25 @@ The below instructions are geared toward BTC, but can be adapted easily to other
 1. Clone this repo
 2. `npm install`
 3. `npm run build`
-4. Edit the "rpc" settings in [credentials.js](app/credentials.js) to target your node
+4. Edit the environment variables of the server to set the proper "rpc" credentials to target your node. See [configuration](#configuration)
 5. Optional: Change the "coin" value in [config.js](app/config.js). Currently supported values are "BTC" and "LTC".
-6. Optional: Add an ipstack.com API access key to [credentials.js](app/credentials.js). Doing so will add a map to the /peers page.
+6. Optional: Add an ipstack.com API access key to the [environment variables](#environment-variables). Doing so will add a map to the /peers page.
 7. `npm start` to start the local server
 8. Visit http://127.0.0.1:3002/
+
+### Configuration
+Some parameters have to be set as environment variables in the server. Alternatively, you can create a `.env` file in the root directory with such parameters and the software will take them from there.
+
+#### Environment variables:
+```
+BTCEXP_RPC_HOST = localhost
+BTCEXP_RPC_PORT = 8332
+BTCEXP_RPC_USERNAME = username
+BTCEXP_RPC_PASSWORD = password
+BTCEXP_IPSTACK_KEY = 0000aaaafffffgggggg
+BTCEXP_COOKIEPASSWORD = 0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+```
+If you omit one parameter, a default value will be considered.
 
 ## Run via Docker
 

--- a/app.js
+++ b/app.js
@@ -69,31 +69,15 @@ app.runOnStartup = function() {
 	global.coinConfigs = coins;
 
 	console.log("Running RPC Explorer for coin: " + global.coinConfig.name);
+	console.log("Connecting via RPC to node at " + config.credentials.rpc.host + ":" + config.credentials.rpc.port);
 
-	var rpcCredentials = null;
-	if (config.credentials.rpc) {
-		rpcCredentials = config.credentials.rpc;
-
-	} else if (process.env.RPC_HOST) {
-		rpcCredentials = {
-			host: process.env.RPC_HOST,
-			port: process.env.RPC_PORT,
-			username: process.env.RPC_USERNAME,
-			password: process.env.RPC_PASSWORD
-		};
-	}
-
-	if (rpcCredentials) {
-		console.log("Connecting via RPC to node at " + config.credentials.rpc.host + ":" + config.credentials.rpc.port);
-
-		global.client = new bitcoinCore({
-			host: rpcCredentials.host,
-			port: rpcCredentials.port,
-			username: rpcCredentials.username,
-			password: rpcCredentials.password,
-			timeout: 5000
-		});
-	}
+	global.client = new bitcoinCore({
+		host: config.credentials.rpc.host,
+		port: config.credentials.rpc.port,
+		username: config.credentials.rpc.username,
+		password: config.credentials.rpc.password,
+		timeout: 5000
+	});
 
 	if (config.donationAddresses) {
 		var getDonationAddressQrCode = function(coinId) {

--- a/app.js
+++ b/app.js
@@ -2,6 +2,9 @@
 
 'use strict';
 
+// load the environment variables
+require('dotenv').config();
+
 var express = require('express');
 var path = require('path');
 var favicon = require('serve-favicon');

--- a/app/config.js
+++ b/app/config.js
@@ -4,7 +4,7 @@ var coins = require("./coins.js");
 var currentCoin = "BTC";
 
 module.exports = {
-	cookiePassword: "0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+	cookiePassword: process.env.BTCEXP_COOKIEPASSWORD || "0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
 	demoSite: true,
 	coin: currentCoin,
 

--- a/app/credentials.js
+++ b/app/credentials.js
@@ -2,21 +2,20 @@ module.exports = {
 	
 	// Edit "rpc" below to target your node.
 	// You may delete this section if you wish to connect manually via the UI.
-
 	rpc: {
-		host:"localhost",
-		port:8332,
-		username:"username",
-		password:"password"
+		host: process.env.BTCEXP_RPC_HOST || "localhost",
+		port: parseInt(process.env.BTCEXP_RPC_PORT) || 8332,
+		username: process.env.BTCEXP_RPC_USERNAME || "username",
+		password: process.env.BTCEXP_RPC_PASSWORD || "password"
 	},
 
 	// optional: enter your api access key from ipstack.com below
 	// to include a map of the estimated locations of your node's
 	// peers
-	ipStackComApiAccessKey:"",
+	ipStackComApiAccessKey: process.env.BTCEXP_IPSTACK_KEY || "",
 
 	// optional: GA tracking code
-	googleAnalyticsTrackingId:"",
+	googleAnalyticsTrackingId: process.env.BTCEXP_GANALYTICS_TRACKING || "",
 
 	// optional: sentry.io error-tracking url
 	sentryUrl:"",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "crypto-js": "3.1.9-1",
     "debug": "~2.6.0",
     "decimal.js": "7.2.3",
+    "dotenv": "^6.0.0",
     "express": "~4.16.3",
     "express-session": "1.15.6",
     "jstransformer-markdown-it": "^2.0.0",


### PR DESCRIPTION
Added the "dotenv" module to handle the env variables merged with the .env file.
Reasons:
1. config files (like `credentials.js`) are committed and should not be changed locally, instead change the server environment variables
2. sensitive information should not be committed, and it's a good practice to keep them in the env so they are server specific

Also adjusted the README file to mention the environment variables.