### PR TITLE
bugfix: Filter empty Electrum servers

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -25,7 +25,7 @@ var cookieSecret = process.env.BTCEXP_COOKIE_SECRET
  || "0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
 
 
-var electrumXServerUriStrings = (process.env.BTCEXP_ELECTRUMX_SERVERS || "").split(',');
+var electrumXServerUriStrings = (process.env.BTCEXP_ELECTRUMX_SERVERS || "").split(',').filter(Boolean);
 var electrumXServers = [];
 for (var i = 0; i < electrumXServerUriStrings.length; i++) {
 	var uri = url.parse(electrumXServerUriStrings[i]);


### PR DESCRIPTION
Without this fix, running btc-rpc-explorer without setting `BTCEXP_ELECTRUMX_SERVERS` was being parsed as single empty-string server, which resulted in the following error:

```
btc-rpc-explorer/app/config.js:33
        electrumXServers.push({protocol:uri.protocol.substring(0, uri.protocol.length - 1), host:uri.hostname, port:parseInt(uri.port)});
                                                     ^

TypeError: Cannot read property 'substring' of null
    at Object.<anonymous> (btc-rpc-explorer/app/config.js:33:47)
```