### PR TITLE
Get sourcecodeVersion and sourcecodeDate only when .git is available

### DIFF
--- a/app.js
+++ b/app.js
@@ -329,8 +329,9 @@ app.runOnStartup = function() {
 		});
 	}
 
-	if (global.sourcecodeVersion == null) {
+	if (global.sourcecodeVersion == null && fs.existsSync('.git')) {
 		simpleGit(".").log(["-n 1"], function(err, log) {
+			if (err) { return console.error('error accessing git repo:', err); }
 			global.sourcecodeVersion = log.all[0].hash.substring(0, 10);
 			global.sourcecodeDate = log.all[0].date.substring(0, "0000-00-00".length);
 		});

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -124,10 +124,11 @@ html(lang="en")
 								dd
 									a(href="https://github.com/janoside/btc-rpc-explorer") github.com/janoside/btc-rpc-explorer
 
-								dt Running Version
-								dd
-									a(href=("https://github.com/janoside/btc-rpc-explorer/commit/" + sourcecodeVersion)) #{sourcecodeVersion}
-									span(style="color: #ccc;")  (#{sourcecodeDate})
+								if (sourcecodeVersion)
+									dt Running Version
+									dd
+										a(href=("https://github.com/janoside/btc-rpc-explorer/commit/" + sourcecodeVersion)) #{sourcecodeVersion}
+										span(style="color: #ccc;")  (#{sourcecodeDate})
 
 								if (config.demoSite)
 									dt Public Demos


### PR DESCRIPTION
It might not be when installing btc-rpc-explorer globally (via `npm install -g`).

Without this, running btc-rpc-explorer without `.git` resulted in:

```
fatal: Not a git repository (or any parent up to mount point /home/user)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).

Unhandled Rejection at: Promise Promise {
  <rejected> TypeError: Cannot read property 'all' of null
    at btc-rpc-explorer/app.js:334:35
```