### PR TITLE
Fix incorrect spaces in .env sample

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,47 +1,47 @@
 # The active coin: BTC/LTC
-#BTCEXP_COIN = BTC
+#BTCEXP_COIN=BTC
 
 # Port to run the site on
-#BTCEXP_PORT = 3002
+#BTCEXP_PORT=3002
 
 # Bitcoin RPC Credentials (URI -OR- HOST/PORT/USER/PASS)
-#BTCEXP_BITCOIND_URI = bitcoin://rpcusername:rpcpassword@127.0.0.1:8332
-#BTCEXP_BITCOIND_HOST = localhost
-#BTCEXP_BITCOIND_PORT = 8332
-#BTCEXP_BITCOIND_USER = rpcusername
-#BTCEXP_BITCOIND_PASS = rpcpassword
-#BTCEXP_BITCOIND_COOKIE = /path/to/bitcoind/.cookie
+#BTCEXP_BITCOIND_URI=bitcoin://rpcusername:rpcpassword@127.0.0.1:8332
+#BTCEXP_BITCOIND_HOST=localhost
+#BTCEXP_BITCOIND_PORT=8332
+#BTCEXP_BITCOIND_USER=rpcusername
+#BTCEXP_BITCOIND_PASS=rpcpassword
+#BTCEXP_BITCOIND_COOKIE=/path/to/bitcoind/.cookie
 
 # Optional ElectrumX Servers, used to display address transaction histories
 # Ref: https://uasf.saltylemon.org/electrum
-#BTCEXP_ELECTRUMX_SERVERS = tls://electrumx.server.com:50002,tcp://127.0.0.1:50001,...
+#BTCEXP_ELECTRUMX_SERVERS=tls://electrumx.server.com:50002,tcp://127.0.0.1:50001,...
 
 # Optional InfluxDB Credentials (URI -OR- HOST/PORT/DBNAME/USER/PASS)
-#BTCEXP_ENABLE_INFLUXDB = true
-#BTCEXP_INFLUXDB_URI = influx://username:password@127.0.0.1:8086
-#BTCEXP_INFLUXDB_HOST = 127.0.0.1
-#BTCEXP_INFLUXDB_PORT = 8086
-#BTCEXP_INFLUXDB_DBNAME = influxdb
-#BTCEXP_INFLUXDB_USER = dbuser
-#BTCEXP_INFLUXDB_PASS = dbpassword
+#BTCEXP_ENABLE_INFLUXDB=true
+#BTCEXP_INFLUXDB_URI=influx://username:password@127.0.0.1:8086
+#BTCEXP_INFLUXDB_HOST=127.0.0.1
+#BTCEXP_INFLUXDB_PORT=8086
+#BTCEXP_INFLUXDB_DBNAME=influxdb
+#BTCEXP_INFLUXDB_USER=dbuser
+#BTCEXP_INFLUXDB_PASS=dbpassword
 
-#BTCEXP_COOKIE_SECRET = 0000aaaafffffgggggg
+#BTCEXP_COOKIE_SECRET=0000aaaafffffgggggg
 
 # Whether public-demo aspects of the site are active
-#BTCEXP_DEMO = true
+#BTCEXP_DEMO=true
 
 # Don't request currency exchange rates
-#BTCEXP_NO_RATES = true
+#BTCEXP_NO_RATES=true
 
 # Password protection for site via basic auth (enter any username, only the password is checked)
-#BTCEXP_BASIC_AUTH_PASSWORD = mypassword
+#BTCEXP_BASIC_AUTH_PASSWORD=mypassword
 
 # Enable to allow access to all RPC methods
-#BTCEXP_RPC_ALLOWALL = true
+#BTCEXP_RPC_ALLOWALL=true
 
 # Custom RPC method blacklist
-#BTCEXP_RPC_BLACKLIST = signrawtransaction,sendtoaddress,stop,...
+#BTCEXP_RPC_BLACKLIST=signrawtransaction,sendtoaddress,stop,...
 
-#BTCEXP_IPSTACK_KEY = 0000aaaafffffgggggg
-#BTCEXP_GANALYTICS_TRACKING = UA-XXXX-X
-#BTCEXP_SENTRY_URL = https://00000fffffff@sentry.io/XXXX
+#BTCEXP_IPSTACK_KEY=0000aaaafffffgggggg
+#BTCEXP_GANALYTICS_TRACKING=UA-XXXX-X
+#BTCEXP_SENTRY_URL=https://00000fffffff@sentry.io/XXXX


### PR DESCRIPTION
Sample .env file is confusing cos docker-compose doesn't catch spaces in environment variable declarations