### PR TITLE
Limit stats intervals to the history we have available

### DIFF
--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -48,8 +48,12 @@ router.get("/", function(req, res) {
 		res.locals.getblockchaininfo = getblockchaininfo;
 
 		if (getblockchaininfo.chain !== 'regtest') {
-			var chainTxStatsIntervals = [ 144, 144 * 7, 144 * 30, 144 * 365 ];
-			res.locals.chainTxStatsLabels = [ "24 hours", "1 week", "1 month", "1 year", "All time" ];
+			var chainTxStatsIntervals = [ 144, 144 * 7, 144 * 30, 144 * 365]
+				.filter(numBlocks => numBlocks < getblockchaininfo.blocks);
+			res.locals.chainTxStatsLabels = [ "24 hours", "1 week", "1 month", "1 year" ]
+				.slice(0, chainTxStatsIntervals.length)
+				.concat("All time");
+
 			for (var i = 0; i < chainTxStatsIntervals.length; i++) {
 				promises.push(coreApi.getChainTxStats(chainTxStatsIntervals[i]));
 			}


### PR DESCRIPTION
Related to #84. These out-of-bound errors might happen not just in regtest, but also if we have a node that still hasn't synced at least one year of history, or with a node for an altcoin that's still less than 1 years old.

With this patch, btc-rpc-explorer will only display stats going back as far as it has available data for.