### PR TITLE
Use Docker multistage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM node:8
+FROM node:8 as builder
 WORKDIR /workspace
 COPY . .
 RUN npm install
+
+FROM node:8-alpine
+WORKDIR /workspace
+COPY --from=builder /workspace .
 CMD npm start
 EXPOSE 3002


### PR DESCRIPTION
The building will happen on the regular `node:8` image, but the final image will run `node:8-alpine` which will reduce the image size from 960 MB to 120 MB

https://docs.docker.com/develop/develop-images/multistage-build/