### PR TITLE
Fix error when Block block rewards gets zero in Regtest

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -385,7 +385,11 @@ function getBlockTotalFeesFromCoinbaseTxAndBlockHeight(coinbaseTx, blockHeight) 
 		}
 	}
 
-	return totalOutput.minus(new Decimal(blockReward));
+	if (blockReward < 1e-8 || blockReward == null) {
+		return totalOutput;
+	} else {
+		return totalOutput.minus(new Decimal(blockReward));
+}
 }
 
 function refreshExchangeRates() {


### PR DESCRIPTION
This fixes an error when the block reward goes to zero.
With this bug it was not possible to load the website anymore, when the block reward went to zero.