### PR TITLE
Handle "history too large" case for Electrum Rust

### DIFF
--- a/views/address.pug
+++ b/views/address.pug
@@ -304,11 +304,11 @@ block content
 											span Failed to retrieve transaction history from ElectrumX. See 
 											a(href="https://github.com/janoside/btc-rpc-explorer/issues/67") Issue #67
 											span  for more information.
-
-										else if (err.e && err.e.error && err.e.error.message.endsWith("transactions found, query may take a long time"))
-											span Failed to retrieve transaction history from Electrum Rust Server. See 
+										
+										else if (err.e && err.e.error && err.e.error == "failed to get confirmed status") 
+											span Failed to retrieve transaction history from Electrum Rust Server. See
 											a(href="https://github.com/janoside/btc-rpc-explorer/issues/67") Issue #67
-											span  for more information. Consider starting Electrum Rust Server with a custom --txid-limit argument, to support longer transaction histories.
+											span  for more information. As a workaround, consider starting Electrum Rust Server with a custom --txid-limit argument, to support longer transaction histories.
 											
 										else if (err == "No address API configured")
 											span No address API is configured. See 

--- a/views/address.pug
+++ b/views/address.pug
@@ -305,6 +305,11 @@ block content
 											a(href="https://github.com/janoside/btc-rpc-explorer/issues/67") Issue #67
 											span  for more information.
 
+										else if (err.e && err.e.error && err.e.error.message.endsWith("transactions found, query may take a long time"))
+											span Failed to retrieve transaction history from Electrum Rust Server. See 
+											a(href="https://github.com/janoside/btc-rpc-explorer/issues/67") Issue #67
+											span  for more information. Consider starting Electrum Rust Server with a custom --txid-limit argument, to support longer transaction histories.
+											
 										else if (err == "No address API configured")
 											span No address API is configured. See 
 											a(href="https://github.com/janoside/btc-rpc-explorer/blob/master/.env-sample") the example configuration file


### PR DESCRIPTION
Correctly handle the "history too large" error in case of Electrum Rust Server.

The "history too large" error msg is thrown by ElectrumX -- see https://github.com/kyuupichan/electrumx/blob/79a987ab4e9e2eb9e53ccc767291cebed187c4a6/electrumx/server/session.py#L740

The Electrum Rust Server version of the same error has an error message ending in "... transactions found, query may take a long time" -- see https://github.com/romanz/electrs/blob/9ecf131e3da4c2765e72f47453afc803a3650641/src/query.rs#L288

They are both thrown in the same situation, but Electrum Rust offers a way to control that limit.

This commit looks for that ending in the error message and displays an appropriate info message, suggestiong a workaround specific to Electrum Rust Server (i.e. increasing the --txid-limit setting)