### PR TITLE
fix 4 low severity node vulnerability

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1502,9 +1502,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"longest": {
 			"version": "1.0.1",


### PR DESCRIPTION
Found 5 low severity node vulnerability while installing. Running `npm audit fix` bumps the version of *lodash* from 4.17.15 to 4.17.19 which resolves 4 out of 5 vulnerability.

Perhaps using [snyk.io](https://snyk.io/) bot would fix such issues in the future.