### PR TITLE
Fix Docker example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To match the features visible on the demo site at [https://explorer.btc21.org](h
 ## Run via Docker
 
 1. `docker build -t btc-rpc-explorer .`
-2. `docker run -p 3002:3002 -it btc-rpc-explorer`
+2. `docker run -it -p 3002:3002 -e BTCEXP_HOST=0.0.0.0 btc-rpc-explorer`
 
 
 ## Reverse proxy with HTTPS


### PR DESCRIPTION
By default `btc-rpc-explorer` listens on 127.0.0.1, so if you run `docker run -p 3002:3002 -it btc-rpc-explorer` it'll only accept connections from inside the container, and not on the host.

Passing in `-e BTCEXP_HOST=0.0.0.0` like:

```
docker run -it -p 3002:3002 -e BTCEXP_HOST=0.0.0.0 btc-rpc-explorer
```

Tells `btc-rpc-explorer` to accept connections from anywhere, which is safe because you can handle what the host port is listening on in Docker.

For example if you want to limit to only local connections with Docker you would do:

```
docker run -it -p 127.0.0.1:3002:3002 -e BTCEXP_HOST=0.0.0.0 btc-rpc-explorer
```