### PR TITLE
Sanitize V8 flag input

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -3,8 +3,9 @@ var debug = require('debug')('www');
 var app = require('../app');
 
 const v8 = require('v8');
-v8.setFlagsFromString("--max_old_space_size=" + (process.env.BTCEXP_OLD_SPACE_MAX_SIZE || 1024));
-debug(`Set max_old_space_size to ${(process.env.BTCEXP_OLD_SPACE_MAX_SIZE || 1024)} MB`);
+const maxOldSpaceSize = parseInt(process.env.BTCEXP_OLD_SPACE_MAX_SIZE, 10) || 1024;
+v8.setFlagsFromString(`--max_old_space_size=${maxOldSpaceSize}`);
+debug(`Set max_old_space_size to ${maxOldSpaceSize} MB`);
 
 app.set('port', process.env.PORT || process.env.BTCEXP_PORT || 3002);
 app.set('host', process.env.BTCEXP_HOST || '127.0.0.1');


### PR DESCRIPTION
By passing the value of the `BTCEXP_OLD_SPACE_MAX_SIZE` environment variable directly in to `v8.setFlagsFromString()` without sanitization it means that if untrusted code can set environment variables it could influence V8 behaviour.

As an example if some untrusted code was able to set:
```bash
BTCEXP_OLD_SPACE_MAX_SIZE="1024 --random-seed 1"
```

then `--max_old_space_size=1024 --random-seed 1` will get passed directly to V8 and set the seed for the Node.js random number generator to 1 rendering most cryptographic operations insecure.

This is low severity because it's unlikely untrusted code could set environment variables, but still worth sanitizing to be safe.