### PR TITLE
Fixed replacing when generating the SSO token

### DIFF
--- a/app/sso.js
+++ b/app/sso.js
@@ -6,7 +6,7 @@ function generateToken() {
 	// But since we're going to base64 it and there would be padding (==),
 	// It's a wasted space, why not use padding for some additional entropy? :)
 	// The replacing is to make it URL-safe
-	return crypto.randomBytes(18).toString("base64").replace('+', '-').replace('/', '_')
+	return crypto.randomBytes(18).toString("base64").replace(/\+/g, '-').replace(/\//g, '_')
 }
 
 function updateToken(tokenFile) {


### PR DESCRIPTION
As @shesek
[pointed out](https://github.com/janoside/btc-rpc-explorer/pull/260#discussion_r543884234)
the `replace` method would only replace the first occurrence, not all of
them. This change fixes it.