### PR TITLE
add git to a docker image, fixes #169

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ RUN npm install
 FROM node:8-alpine
 WORKDIR /workspace
 COPY --from=builder /workspace .
+RUN apk --update add git
 CMD npm start
 EXPOSE 3002


### PR DESCRIPTION
apparently bootstrap_node.js wants to spawn git.