### PR TITLE
Prevent 404 pages from hanging

### DIFF
--- a/app.js
+++ b/app.js
@@ -616,6 +616,7 @@ app.use(function(req, res, next) {
 	var memdiff = process.memoryUsage().heapUsed - req.startMem;
 
 	debugPerfLog("Finished action '%s' in %d ms", req.path, time);
+	next();
 });
 
 /// catch 404 and forwarding to error handler


### PR DESCRIPTION
Without this, 404 pages hang forever without a reply.