### PR TITLE
Set one error handler only

### DIFF
--- a/app.js
+++ b/app.js
@@ -637,17 +637,17 @@ if (app.get('env') === 'development') {
 			error: err
 		});
 	});
-}
-
 // production error handler
 // no stacktraces leaked to user
-app.use(function(err, req, res, next) {
-	res.status(err.status || 500);
-	res.render('error', {
-		message: err.message,
-		error: {}
+} else {
+	app.use(function(err, req, res, next) {
+		res.status(err.status || 500);
+		res.render('error', {
+			message: err.message,
+			error: {}
+		});
 	});
-});
+}
 
 app.locals.moment = moment;
 app.locals.Decimal = Decimal;


### PR DESCRIPTION
Running both one after the other resulted in:

    Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client