### PR TITLE
Graceful degradation for pruned and txindex-less nodes 

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -110,6 +110,9 @@
 # Default: 1024
 #BTCEXP_OLD_SPACE_MAX_SIZE=2048
 
+# The number of recent blocks to search for transactions when txindex is disabled
+#BTCEXP_NOTXINDEX_SEARCH_DEPTH=3
+
 # Show tools list in a sub-nav at top of screen
 # Default: true
 BTCEXP_UI_SHOW_TOOLS_SUBHEADER=true

--- a/.env-sample
+++ b/.env-sample
@@ -44,6 +44,9 @@
 # used if BTCEXP_ADDRESS_API=electrumx
 #BTCEXP_ELECTRUMX_SERVERS=tls://electrumx.server.com:50002,tcp://127.0.0.1:50001,...
 
+# Use the Electrumx server as an external txindex. This is only available in Electrs.
+#BTCEXP_ELECTRUM_TXINDEX=true
+
 # Set number of concurrent RPC requests. Should be lower than your node's "rpcworkqueue" value.
 # Note that Bitcoin Core's default rpcworkqueue=16.
 # Default: 10

--- a/app.js
+++ b/app.js
@@ -193,29 +193,29 @@ function verifyRpcConnection() {
 	if (!global.activeBlockchain) {
 		debugLog(`Verifying RPC connection...`);
 
-		coreApi.getNetworkInfo().then(function(getnetworkinfo) {
-			coreApi.getBlockchainInfo().then(function(getblockchaininfo) {
-				global.activeBlockchain = getblockchaininfo.chain;
+		Promise.all([
+			coreApi.getNetworkInfo(),
+			coreApi.getBlockchainInfo(),
+			coreApi.getIndexInfo(),
+		]).then(([ getnetworkinfo, getblockchaininfo, getindexinfo ]) => {
+			global.activeBlockchain = getblockchaininfo.chain;
 
-				// we've verified rpc connection, no need to keep trying
-				clearInterval(global.verifyRpcConnectionIntervalId);
+			// we've verified rpc connection, no need to keep trying
+			clearInterval(global.verifyRpcConnectionIntervalId);
 
-				onRpcConnectionVerified(getnetworkinfo, getblockchaininfo);
-
-			}).catch(function(err) {
-				utils.logError("329u0wsdgewg6ed", err);
-			});
+			onRpcConnectionVerified(getnetworkinfo, getblockchaininfo, getindexinfo);
 		}).catch(function(err) {
 			utils.logError("32ugegdfsde", err);
 		});
 	}
 }
 
-function onRpcConnectionVerified(getnetworkinfo, getblockchaininfo) {
+function onRpcConnectionVerified(getnetworkinfo, getblockchaininfo, getindexinfo) {
 	// localservicenames introduced in 0.19
 	var services = getnetworkinfo.localservicesnames ? ("[" + getnetworkinfo.localservicesnames.join(", ") + "]") : getnetworkinfo.localservices;
 
 	global.getnetworkinfo = getnetworkinfo;
+	global.getindexinfo = getindexinfo;
 
 	var bitcoinCoreVersionRegex = /^.*\/Satoshi\:(.*)\/.*$/;
 

--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -839,6 +839,12 @@ function summarizeBlockAnalysisData(blockHeight, tx, inputs) {
 }
 
 function getRawTransactionsWithInputs(txids, maxInputs=-1, blockhash) {
+	// Get just the transactions without their prevouts when txindex is disabled
+	if (global.getindexinfo && !global.getindexinfo.txindex) {
+		return getRawTransactions(txids, blockhash)
+			.then(transactions => ({ transactions, txInputsByTransaction: {} }))
+	}
+
 	return new Promise(function(resolve, reject) {
 		getRawTransactions(txids, blockhash).then(function(transactions) {
 			var maxInputsTracked = config.site.txMaxInput;
@@ -895,11 +901,7 @@ function getRawTransactionsWithInputs(txids, maxInputs=-1, blockhash) {
 				});
 
 				resolve({ transactions:transactions, txInputsByTransaction:txInputsByTransaction });
-			}).catch(function (err) {
-				debugLog("fetching prevouts failed:", err);
-				// likely due to pruning or no txindex, report the error but continue with an empty inputs map
-				resolve({ transactions:transactions, txInputsByTransaction: {} });
-			});
+			}).catch(reject);
 		}).catch(reject);
 	});
 }

--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -548,6 +548,12 @@ function getBlockByHeight(blockHeight) {
 	});
 }
 
+function getBlockHashByHeight(blockHeight) {
+	return tryCacheThenRpcApi(blockCache, "getBlockHashByHeight-" + blockHeight, ONE_HR, function() {
+		return rpcApi.getBlockHashByHeight(blockHeight);
+	});
+}
+
 function getBlocksByHeight(blockHeights) {
 	return new Promise(function(resolve, reject) {
 		var promises = [];
@@ -1069,6 +1075,7 @@ module.exports = {
 	getMiningInfo: getMiningInfo,
 	getIndexInfo: getIndexInfo,
 	getBlockByHeight: getBlockByHeight,
+	getBlockHashByHeight: getBlockHashByHeight,
 	getBlocksByHeight: getBlocksByHeight,
 	getBlockByHash: getBlockByHash,
 	getBlocksByHash: getBlocksByHash,

--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -228,6 +228,10 @@ function getMempoolInfo() {
 	return tryCacheThenRpcApi(miscCache, "getMempoolInfo", 5 * ONE_SEC, rpcApi.getMempoolInfo);
 }
 
+function getIndexInfo() {
+	return tryCacheThenRpcApi(miscCache, "getIndexInfo", 10 * ONE_SEC, rpcApi.getIndexInfo);
+}
+
 function getMempoolTxids() {
 	// no caching, that would be dumb
 	return rpcApi.getMempoolTxids();
@@ -1063,6 +1067,7 @@ module.exports = {
 	getMempoolInfo: getMempoolInfo,
 	getMempoolTxids: getMempoolTxids,
 	getMiningInfo: getMiningInfo,
+	getIndexInfo: getIndexInfo,
 	getBlockByHeight: getBlockByHeight,
 	getBlocksByHeight: getBlocksByHeight,
 	getBlockByHash: getBlockByHash,

--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -626,9 +626,9 @@ function getBlocksByHash(blockHashes) {
 	});
 }
 
-function getRawTransaction(txid) {
+function getRawTransaction(txid, blockhash) {
 	var rpcApiFunction = function() {
-		return rpcApi.getRawTransaction(txid);
+		return rpcApi.getRawTransaction(txid, blockhash);
 	};
 
 	return tryCacheThenRpcApi(txCache, "getRawTransaction-" + txid, ONE_HR, rpcApiFunction, shouldCacheTransaction);
@@ -720,11 +720,11 @@ function getAddress(address) {
 	});
 }
 
-function getRawTransactions(txids) {
+function getRawTransactions(txids, blockhash) {
 	return new Promise(function(resolve, reject) {
 		var promises = [];
 		for (var i = 0; i < txids.length; i++) {
-			promises.push(getRawTransaction(txids[i]));
+			promises.push(getRawTransaction(txids[i], blockhash));
 		}
 
 		Promise.all(promises).then(function(results) {
@@ -828,9 +828,9 @@ function summarizeBlockAnalysisData(blockHeight, tx, inputs) {
 	return txSummary;
 }
 
-function getRawTransactionsWithInputs(txids, maxInputs=-1) {
+function getRawTransactionsWithInputs(txids, maxInputs=-1, blockhash) {
 	return new Promise(function(resolve, reject) {
-		getRawTransactions(txids).then(function(transactions) {
+		getRawTransactions(txids, blockhash).then(function(transactions) {
 			var maxInputsTracked = config.site.txMaxInput;
 			
 			if (maxInputs <= 0) {
@@ -885,10 +885,12 @@ function getRawTransactionsWithInputs(txids, maxInputs=-1) {
 				});
 
 				resolve({ transactions:transactions, txInputsByTransaction:txInputsByTransaction });
+			}).catch(function (err) {
+				debugLog("fetching prevouts failed:", err);
+				// likely due to pruning or no txindex, report the error but continue with an empty inputs map
+				resolve({ transactions:transactions, txInputsByTransaction: {} });
 			});
-		}).catch(function(err) {
-			reject(err);
-		});
+		}).catch(reject);
 	});
 }
 
@@ -905,7 +907,7 @@ function getBlockByHashWithTransactions(blockHash, txLimit, txOffset) {
 				txids.push(block.tx[i]);
 			}
 
-			getRawTransactionsWithInputs(txids, config.site.txMaxInput).then(function(txsResult) {
+			getRawTransactionsWithInputs(txids, config.site.txMaxInput, blockHash).then(function(txsResult) {
 				if (txsResult.transactions && txsResult.transactions.length > 0) {
 					block.coinbaseTx = txsResult.transactions[0];
 					block.totalFees = utils.getBlockTotalFeesFromCoinbaseTxAndBlockHeight(block.coinbaseTx, block.height);
@@ -918,11 +920,16 @@ function getBlockByHashWithTransactions(blockHash, txLimit, txOffset) {
 				}
 
 				resolve({ getblock:block, transactions:txsResult.transactions, txInputsByTransaction:txsResult.txInputsByTransaction });
+			}).catch(function(err) {
+				// likely due to pruning or no txindex, report the error but continue with an empty transaction list
+				resolve({ getblock:block, transactions:[], txInputsByTransaction:{} });
 			});
-		}).catch(function(err) {
-			reject(err);
-		});
+		}).catch(reject);
 	});
+}
+
+function getTxOut(txid, vout) {
+	return rpcApi.getTxOut(txid, vout)
 }
 
 function getHelp() {
@@ -1084,5 +1091,6 @@ module.exports = {
 	getBlocksStatsByHeight: getBlocksStatsByHeight,
 	buildBlockAnalysisData: buildBlockAnalysisData,
 	getBlockHeaderByHeight: getBlockHeaderByHeight,
-	getBlockHeadersByHeight: getBlockHeadersByHeight
+	getBlockHeadersByHeight: getBlockHeadersByHeight,
+	getTxOut: getTxOut
 };

--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -268,6 +268,17 @@ function getRawTransaction(txid, blockhash) {
 }
 
 async function noTxIndexTransactionLookup(txid) {
+	// Try looking up with an external Electrum server, using 'get_confirmed_blockhash'.
+	// This is only available in Electrs and requires enabling BTCEXP_ELECTRUM_TXINDEX.
+	if (config.addressApi == "electrumx" && config.electrumTxIndex) {
+		try {
+			var blockhash = await electrumAddressApi.lookupTxBlockHash(txid);
+			return await getRawTransaction(txid, blockhash);
+		} catch (err) {
+			debugLog(`Electrs blockhash lookup failed for ${txid}:`, err);
+		}
+	}
+
 	// Try looking up in wallet transactions
 	for (var wallet of await listWallets()) {
 		try { return await getWalletTransaction(wallet, txid); }

--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -193,6 +193,10 @@ function getBlockHeaderByHeight(blockHeight) {
 	});
 }
 
+function getBlockHashByHeight(blockHeight) {
+	return getRpcDataWithParams({method:"getblockhash", parameters:[blockHeight]});
+}
+
 function getBlockByHash(blockHash) {
 	debugLog("getBlockByHash: %s", blockHash);
 
@@ -516,6 +520,7 @@ module.exports = {
 	getBlockStatsByHeight: getBlockStatsByHeight,
 	getBlockHeaderByHash: getBlockHeaderByHash,
 	getBlockHeaderByHeight: getBlockHeaderByHeight,
+	getBlockHashByHeight: getBlockHashByHeight,
 	getTxOut: getTxOut,
 
 	minRpcVersions: minRpcVersions

--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -50,6 +50,10 @@ function getMiningInfo() {
 	return getRpcData("getmininginfo");
 }
 
+function getIndexInfo() {
+	return getRpcData("getindexinfo");
+}
+
 function getUptimeSeconds() {
 	return getRpcData("uptime");
 }
@@ -217,6 +221,10 @@ function getAddress(address) {
 
 function getRawTransaction(txid, blockhash) {
 	debugLog("getRawTransaction: %s", txid);
+
+	if (global.getindexinfo && !global.getindexinfo.txindex && !blockhash) {
+		return Promise.reject(new Error('Cannot fetch tx without blockhash, txindex is off'))
+	}
 
 	return new Promise(function(resolve, reject) {
 		if (coins[config.coin].genesisCoinbaseTransactionIdsByNetwork[global.activeBlockchain] && txid == coins[config.coin].genesisCoinbaseTransactionIdsByNetwork[global.activeBlockchain]) {
@@ -488,6 +496,7 @@ module.exports = {
 	getMempoolInfo: getMempoolInfo,
 	getMempoolTxids: getMempoolTxids,
 	getMiningInfo: getMiningInfo,
+	getIndexInfo: getIndexInfo,
 	getBlockByHeight: getBlockByHeight,
 	getBlockByHash: getBlockByHash,
 	getRawTransaction: getRawTransaction,

--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -226,10 +226,6 @@ function getAddress(address) {
 function getRawTransaction(txid, blockhash) {
 	debugLog("getRawTransaction: %s", txid);
 
-	if (global.getindexinfo && !global.getindexinfo.txindex && !blockhash) {
-		return Promise.reject(new Error('Cannot fetch tx without blockhash, txindex is off'))
-	}
-
 	return new Promise(function(resolve, reject) {
 		if (coins[config.coin].genesisCoinbaseTransactionIdsByNetwork[global.activeBlockchain] && txid == coins[config.coin].genesisCoinbaseTransactionIdsByNetwork[global.activeBlockchain]) {
 			// copy the "confirmations" field from genesis block to the genesis-coinbase tx

--- a/app/config.js
+++ b/app/config.js
@@ -49,7 +49,8 @@ for (var i = 0; i < electrumXServerUriStrings.length; i++) {
 	"BTCEXP_DEMO",
 	"BTCEXP_PRIVACY_MODE",
 	"BTCEXP_NO_INMEMORY_RPC_CACHE",
-	"BTCEXP_RPC_ALLOWALL"
+	"BTCEXP_RPC_ALLOWALL",
+	"BTCEXP_ELECTRUM_TXINDEX",
 
 ].forEach(function(item) {
 	if (process.env[item] === undefined) {
@@ -170,6 +171,7 @@ module.exports = {
 	],
 
 	addressApi:process.env.BTCEXP_ADDRESS_API,
+	electrumTxIndex:process.env.BTCEXP_ELECTRUM_TXINDEX != "false",
 	electrumXServers:electrumXServers,
 
 	redisUrl:process.env.BTCEXP_REDIS_URL,

--- a/app/config.js
+++ b/app/config.js
@@ -92,6 +92,8 @@ module.exports = {
 	
 	rpcConcurrency: (process.env.BTCEXP_RPC_CONCURRENCY || 10),
 
+	noTxIndexSearchDepth: (+process.env.BTCEXP_NOTXINDEX_SEARCH_DEPTH || 3),
+
 	rpcBlacklist:
 	  process.env.BTCEXP_RPC_ALLOWALL.toLowerCase() == "true"  ? []
 	: process.env.BTCEXP_RPC_BLACKLIST ? process.env.BTCEXP_RPC_BLACKLIST.split(',').filter(Boolean)

--- a/app/utils.js
+++ b/app/utils.js
@@ -451,26 +451,30 @@ function getTxTotalInputOutputValues(tx, txInputs, blockHeight) {
 	var totalOutputValue = new Decimal(0);
 
 	try {
-		for (var i = 0; i < tx.vin.length; i++) {
-			if (tx.vin[i].coinbase) {
-				totalInputValue = totalInputValue.plus(new Decimal(coinConfig.blockRewardFunction(blockHeight, global.activeBlockchain)));
+		if (txInputs) {
+			for (var i = 0; i < tx.vin.length; i++) {
+				if (tx.vin[i].coinbase) {
+					totalInputValue = totalInputValue.plus(new Decimal(coinConfig.blockRewardFunction(blockHeight, global.activeBlockchain)));
 
-			} else {
-				var txInput = txInputs[i];
+				} else {
+					var txInput = txInputs[i];
 
-				if (txInput) {
-					try {
-						var vout = txInput;
-						if (vout.value) {
-							totalInputValue = totalInputValue.plus(new Decimal(vout.value));
+					if (txInput) {
+						try {
+							var vout = txInput;
+							if (vout.value) {
+								totalInputValue = totalInputValue.plus(new Decimal(vout.value));
+							}
+						} catch (err) {
+							logError("2397gs0gsse", err, {txid:tx.txid, vinIndex:i});
 						}
-					} catch (err) {
-						logError("2397gs0gsse", err, {txid:tx.txid, vinIndex:i});
 					}
 				}
 			}
+		} else {
+			totalInputValue = null
 		}
-		
+
 		for (var i = 0; i < tx.vout.length; i++) {
 			totalOutputValue = totalOutputValue.plus(new Decimal(tx.vout[i].value));
 		}

--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -35,9 +35,7 @@ router.get("/blocks-by-height/:blockHeights", function(req, res, next) {
 
 	coreApi.getBlocksByHeight(blockHeights).then(function(result) {
 		res.json(result);
-
-		next();
-	});
+	}).catch(next);
 });
 
 router.get("/block-headers-by-height/:blockHeights", function(req, res, next) {

--- a/routes/baseRouter.js
+++ b/routes/baseRouter.js
@@ -435,7 +435,7 @@ router.get("/blocks", function(req, res, next) {
 
 		promises.push(coreApi.getBlocksByHeight(blockHeights));
 
-		promises.push(coreApi.getBlocksStatsByHeight(blockHeights));
+		promises.push(coreApi.getBlocksStatsByHeight(blockHeights).catch(_ => ({})));
 
 		Promise.all(promises).then(function(promiseResults) {
 			res.locals.blocks = promiseResults[0];
@@ -665,9 +665,10 @@ router.get("/block-height/:blockHeight", function(req, res, next) {
 				resolve();
 
 			}).catch(function(err) {
-				res.locals.pageErrors.push(utils.logError("983yr435r76d", err));
-
-				reject(err);
+				// unavailable, likely due to pruning
+				debugLog('Failed loading block stats', err)
+				res.locals.result.blockstats = null;
+				resolve();
 			});
 		}));
 
@@ -747,9 +748,9 @@ router.get("/block/:blockHash", function(req, res, next) {
 			resolve();
 
 		}).catch(function(err) {
-			res.locals.pageErrors.push(utils.logError("21983ue8hye", err));
-			
-			reject(err);
+			// unavailable, likely due to pruning
+			debugLog('Failed loading block stats', err)
+			resolve();
 		});
 	}));
 

--- a/routes/baseRouter.js
+++ b/routes/baseRouter.js
@@ -828,11 +828,16 @@ router.get("/tx/:transactionId", function(req, res, next) {
 
 	res.locals.result = {};
 
-	coreApi.getRawTransactionsWithInputs([txid]).then(function(rawTxResult) {
+	var txPromise = req.query.height
+		? coreApi.getBlockHashByHeight(parseInt(req.query.height))
+				.then(blockhash => coreApi.getRawTransactionsWithInputs([txid], -1, blockhash))
+		: coreApi.getRawTransactionsWithInputs([txid], -1);
+
+	txPromise.then(function(rawTxResult) {
 		var tx = rawTxResult.transactions[0];
 
 		res.locals.result.getrawtransaction = tx;
-		res.locals.result.txInputs = rawTxResult.txInputsByTransaction[txid];
+		res.locals.result.txInputs = rawTxResult.txInputsByTransaction[txid] || {};
 
 		var promises = [];
 

--- a/views/block-analysis.pug
+++ b/views/block-analysis.pug
@@ -47,7 +47,7 @@ block content
 
 									span.text-muted  (#{new Decimal(100 * result.getblock.weight / coinConfig.maxBlockWeight).toDecimalPlaces(2)}% full)
 									
-						else
+						else if (result.getblock.size)
 							div.row
 								div.summary-table-label Size
 								div.summary-table-content.text-monospace #{result.getblock.size.toLocaleString()}
@@ -55,7 +55,7 @@ block content
 
 						div.row
 							div.summary-table-label Transactions
-							div.summary-table-content.text-monospace #{result.getblock.tx.length.toLocaleString()}
+							div.summary-table-content.text-monospace #{result.getblock.nTx.toLocaleString()}
 
 						div.row
 							div.summary-table-label Confirmations

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -22,7 +22,7 @@ ul.nav.nav-tabs.mb-3
 	li.nav-item
 		a.nav-link(data-toggle="tab", href="#tab-json", role="tab") JSON
 
-- var txCount = result.getblock.tx.length;
+- var txCount = result.getblock.nTx
 
 div.tab-content
 	div.tab-pane.active(id="tab-details", role="tabpanel")
@@ -140,18 +140,19 @@ div.tab-content
 										else
 											span 0
 
-							- var blockRewardMax = coinConfig.blockRewardFunction(result.getblock.height, activeBlockchain);
-							- var coinbaseTxTotalOutputValue = new Decimal(0);
-							each vout in result.getblock.coinbaseTx.vout
-								- coinbaseTxTotalOutputValue = coinbaseTxTotalOutputValue.plus(new Decimal(vout.value));
+							if result.getblock.coinbaseTx
+								- var blockRewardMax = coinConfig.blockRewardFunction(result.getblock.height, activeBlockchain);
+								- var coinbaseTxTotalOutputValue = new Decimal(0);
+								each vout in result.getblock.coinbaseTx.vout
+									- coinbaseTxTotalOutputValue = coinbaseTxTotalOutputValue.plus(new Decimal(vout.value));
 
-							if (parseFloat(coinbaseTxTotalOutputValue) < blockRewardMax)
-								div.row
-									div(class=sumTableLabelClass)
-										span.border-dotted(data-toggle="tooltip" title="The miner of this block failed to collect this value. As a result, it is permanently lost.") Value Destroyed
-									div.text-monospace.text-danger(class=sumTableValueClass)
-										- var currencyValue = new Decimal(blockRewardMax).minus(coinbaseTxTotalOutputValue);
-										include ./value-display.pug
+								if (parseFloat(coinbaseTxTotalOutputValue) < blockRewardMax)
+									div.row
+										div(class=sumTableLabelClass)
+											span.border-dotted(data-toggle="tooltip" title="The miner of this block failed to collect this value. As a result, it is permanently lost.") Value Destroyed
+										div.text-monospace.text-danger(class=sumTableValueClass)
+											- var currencyValue = new Decimal(blockRewardMax).minus(coinbaseTxTotalOutputValue);
+											include ./value-display.pug
 
 							if (result.getblock.weight)
 								div.row
@@ -163,10 +164,12 @@ div.tab-content
 										span.text-muted  (#{new Decimal(100 * result.getblock.weight / coinConfig.maxBlockWeight).toDecimalPlaces(2)}% full)
 										
 
-							div.row
-								div(class=sumTableLabelClass) Size
-								div.text-monospace(class=sumTableValueClass) #{result.getblock.size.toLocaleString()} 
-									small B
+
+							if (result.getblock.size)
+								div.row
+									div(class=sumTableLabelClass) Size
+									div.text-monospace(class=sumTableValueClass) #{result.getblock.size.toLocaleString()}
+										small B
 
 							if (result.getblock.miner)
 								div.row
@@ -348,8 +351,11 @@ div.tab-content
 									span.text-muted  (#{result.getblock.chainwork.replace(/^0+/, '')})
 									
 
-		div.card.shadow-sm.mb-3
-			div.card-body.px-2.px-md-3
+		if (!result.getblock.tx.length)
+			div.card.shadow-sm.mb-3: div.card-body.px-2.px-md-3
+				h2.h6.mb-0.d-inline-block #{txCount.toLocaleString()} Transaction#{txCount>1?'s':''} (unavailable due to pruning)
+		else
+			div.card.shadow-sm.mb-3: div.card-body.px-2.px-md-3
 				div.row
 					div.col-md-4
 						h2.h6.mb-0.d-inline-block #{txCount.toLocaleString()} 

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -386,7 +386,7 @@ div.tab-content
 				- var fontawesomeOutputName = "sign-out-alt";
 
 				div
-					- query_height = global.getindexinfo && !global.getindexinfo.txindex ? `?height=${result.getblock.height}` : ''
+					- tx_height_param = global.getindexinfo && !global.getindexinfo.txindex ? `@${result.getblock.height}` : ''
 					each tx, txIndex in result.transactions
 						//pre
 						//	code.json.bg-light #{JSON.stringify(tx, null, 4)}
@@ -394,8 +394,8 @@ div.tab-content
 							div.card-header.text-monospace
 								if (tx && tx.txid)
 									span(title=`Index in Block: #${(txIndex + offset).toLocaleString()}`, data-toggle="tooltip") ##{(txIndex + offset).toLocaleString()}
-									span  &ndash; 
-									a(href=("./tx/" + tx.txid + query_height)) #{tx.txid}
+									span  &ndash;
+									a(href=("./tx/" + tx.txid + tx_height_param)) #{tx.txid}
 
 									if (global.specialTransactions && global.specialTransactions[tx.txid])
 										span  

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -386,6 +386,7 @@ div.tab-content
 				- var fontawesomeOutputName = "sign-out-alt";
 
 				div
+					- query_height = global.getindexinfo && !global.getindexinfo.txindex ? `?height=${result.getblock.height}` : ''
 					each tx, txIndex in result.transactions
 						//pre
 						//	code.json.bg-light #{JSON.stringify(tx, null, 4)}
@@ -394,7 +395,7 @@ div.tab-content
 								if (tx && tx.txid)
 									span(title=`Index in Block: #${(txIndex + offset).toLocaleString()}`, data-toggle="tooltip") ##{(txIndex + offset).toLocaleString()}
 									span  &ndash; 
-									a(href=("./tx/" + tx.txid)) #{tx.txid}
+									a(href=("./tx/" + tx.txid + query_height)) #{tx.txid}
 
 									if (global.specialTransactions && global.specialTransactions[tx.txid])
 										span  

--- a/views/includes/blocks-list.pug
+++ b/views/includes/blocks-list.pug
@@ -110,7 +110,7 @@ div.table-responsive
 								span ?
 
 						
-						td.data-cell.text-monospace.text-right #{block.tx.length.toLocaleString()}
+						td.data-cell.text-monospace.text-right #{block.nTx.toLocaleString()}
 
 						if (blockstatsByHeight)
 							td.data-cell.text-monospace.text-right
@@ -119,22 +119,32 @@ div.table-responsive
 									- var currencyValueDecimals = 0;
 									include ./value-display.pug
 
+									if (block.totalFees == null)
+										- block.totalFees = Decimal(blockstatsByHeight[block.height].totalfee).dividedBy(coinConfig.baseCurrencyUnit.multiplier)
+
 								else
 									span 0
 
 						td.data-cell.text-monospace.text-right
-							- var currencyValue = new Decimal(block.totalFees).dividedBy(block.strippedsize).times(coinConfig.baseCurrencyUnit.multiplier).toDecimalPlaces(1);
-							span #{currencyValue}
-							
+							if block.totalFees && block.strippedsize
+								- var currencyValue = new Decimal(block.totalFees).dividedBy(block.strippedsize).times(coinConfig.baseCurrencyUnit.multiplier).toDecimalPlaces(1);
+								span #{currencyValue}
+							else
+								= 'N/A'
+
 							// idea: show typical tx fee, maybe also optimized fee if not segwit
 							if (false)
 								- var feeEstimateVal = currencyValue.times(166).dividedBy(coinConfig.baseCurrencyUnit.multiplier);
 								span.border-dotted(title=`Value: ${feeEstimateVal}`, data-toggle="tooltip") #{currencyValue}
 
 						td.data-cell.text-monospace.text-right
-							- var currencyValue = new Decimal(block.totalFees);
-							- var currencyValueDecimals = 3;
-							include ./value-display.pug
+							if block.totalFees
+								- var currencyValue = new Decimal(block.totalFees);
+								- var currencyValueDecimals = 3;
+								include ./value-display.pug
+							else
+								= 'N/A'
+
 
 							
 						
@@ -144,7 +154,7 @@ div.table-responsive
 								span #{bSizeK.toLocaleString()}
 
 						if (blocks && blocks.length > 0 && blocks[0].weight)
-							td.data-cell.text-monospace.text-right
+							td.data-cell.text-monospace.text-right: if block.weight
 								if (true)
 									- var full = new Decimal(block.weight).dividedBy(coinConfig.maxBlockWeight).times(100);
 									- var full2 = full.toDP(2);

--- a/views/includes/transaction-io-details.pug
+++ b/views/includes/transaction-io-details.pug
@@ -15,7 +15,7 @@ script.
 
 div.row.text-monospace
 	div.col-lg-6
-		if (txInputs)
+		if (true)
 			- var extraInputCount = 0;
 			each txVin, txVinIndex in tx.vin
 				if (!txVin.coinbase)
@@ -23,8 +23,11 @@ div.row.text-monospace
 					if (txInputs && txInputs[txVinIndex])
 						- var txInput = txInputs[txVinIndex];
 						- var vout = txInput;
+					else
+						- var txInput = {txid:txVin.txid, vout:txVin.vout};
+						- var vout = {};
 
-				if (txVin.coinbase || vout)
+				if true
 					div.clearfix
 						div.tx-io-label
 							a(data-toggle="tooltip", title=("Input #" + txVinIndex.toLocaleString()), style="white-space: nowrap;")
@@ -55,14 +58,15 @@ div.row.text-monospace
 
 										div(id="coinbase-data-hex", style="display: none;")
 											small.font-weight-bold data
-											small (hex) - 
+											small (hex) -
 											small.word-wrap #{txVin.coinbase}
 
 
 									else
 										div.word-wrap
-											small.data-tag.bg-dark.mr-2
-												span(title=`Input Type: ${utils.outputTypeName(vout.scriptPubKey.type)}`, data-toggle="tooltip") #{utils.outputTypeAbbreviation(vout.scriptPubKey.type)}
+											if (vout.scriptPubKey)
+												small.data-tag.bg-dark.mr-2
+													span(title=`Input Type: ${utils.outputTypeName(vout.scriptPubKey.type)}`, data-toggle="tooltip") #{utils.outputTypeAbbreviation(vout.scriptPubKey.type)}
 
 											if (vout.coinbaseSpend)
 												small.data-tag.bg-success.mr-2
@@ -143,12 +147,13 @@ div.row.text-monospace
 								include ./value-display.pug
 				hr
 
-			div.row.mb-5.mb-lg-0
-				div.col
-					div.font-weight-bold.text-left.text-md-right
-						span.d-block.d-md-none Total Input: 
-						- var currencyValue = totalIOValues.input;
-						include ./value-display.pug
+			if (totalIOValues.input)
+				div.row.mb-5.mb-lg-0
+					div.col
+						div.font-weight-bold.text-left.text-md-right
+							span.d-block.d-md-none Total Input:
+							- var currencyValue = totalIOValues.input;
+							include ./value-display.pug
 					
 			
 			

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -154,7 +154,7 @@ html(lang="en")
 
 				if (userMessage)
 					div.alert(class=(userMessageType ? `alert-${userMessageType}` : "alert-warning"), role="alert")
-						span #{userMessage}
+						| !{markdown(userMessage)}
 							
 				
 				div(style="min-height: 500px;")

--- a/views/mining-summary.pug
+++ b/views/mining-summary.pug
@@ -348,7 +348,7 @@ block endOfBody
 				summariesByMiner[miner.name].blockCount++;
 				summariesByMiner[miner.name].transactionCount += block.tx.length;
 				summariesByMiner[miner.name].totalSubsidiesCollected = summariesByMiner[miner.name].totalSubsidiesCollected.add(new Decimal(block.subsidy));
-				summariesByMiner[miner.name].totalFeesCollected = summariesByMiner[miner.name].totalFeesCollected.add(new Decimal(block.totalFees));
+				if (block.totalFees != null) summariesByMiner[miner.name].totalFeesCollected = summariesByMiner[miner.name].totalFeesCollected.add(new Decimal(block.totalFees));
 				summariesByMiner[miner.name].blockSizeTotal += block.size;
 
 				summariesByMiner[miner.name].blockHeights.push(block.height);
@@ -361,7 +361,7 @@ block endOfBody
 				overallSummary.blockCount++;
 				overallSummary.transactionCount += block.tx.length;
 				overallSummary.totalSubsidiesCollected = overallSummary.totalSubsidiesCollected.add(new Decimal(block.subsidy));
-				overallSummary.totalFeesCollected = overallSummary.totalFeesCollected.add(new Decimal(block.totalFees));
+				if (block.totalFees != null) overallSummary.totalFeesCollected = overallSummary.totalFeesCollected.add(new Decimal(block.totalFees));
 				overallSummary.blockSizeTotal += block.size;
 
 				if (blocks[0].weight) {

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -198,6 +198,12 @@ block content
 											else
 												small.data-tag.bg-primary #{minerInfo.name}
 
+							else if (global.getindexinfo && !global.getindexinfo.txindex)
+								div.row
+									div.summary-table-label Fee Paid
+									div.summary-table-content.text-monospace
+										| Unknown
+										span.ml-2(title="Determining the fee requires txindex to be enabled", data-toggle="tooltip"): i.fas.fa-ellipsis-h
 							else
 
 								- var feePaid = new Decimal(totalInputValue).minus(totalOutputValue);

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -198,15 +198,14 @@ block content
 											else
 												small.data-tag.bg-primary #{minerInfo.name}
 
-							else if (global.getindexinfo && !global.getindexinfo.txindex)
+							else if (!mempoolDetails && global.getindexinfo && !global.getindexinfo.txindex)
 								div.row
 									div.summary-table-label Fee Paid
 									div.summary-table-content.text-monospace
 										| Unknown
-										span.ml-2(title="Determining the fee requires txindex to be enabled", data-toggle="tooltip"): i.fas.fa-ellipsis-h
+										span.ml-2(title="Determining the fee of confirmed transactions requires txindex to be enabled", data-toggle="tooltip"): i.fas.fa-ellipsis-h
 							else
-
-								- var feePaid = new Decimal(totalInputValue).minus(totalOutputValue);
+								- var feePaid = mempoolDetails ? new Decimal(mempoolDetails.entry.fees.base) : new Decimal(totalInputValue).minus(totalOutputValue);
 
 								div.row
 									div.summary-table-label Fee Paid
@@ -214,7 +213,7 @@ block content
 										- var currencyValue = feePaid;
 										include includes/value-display.pug
 
-										if (feePaid > 0)
+										if (feePaid > 0 && totalInputValue > 0)
 											- var item1 = utils.formatCurrencyAmount(totalInputValue, currencyFormatType);
 											- var item2 = utils.formatCurrencyAmount(totalOutputValue, currencyFormatType);
 											span.ml-2(title=(item1.simpleVal + " - " + item2.simpleVal), data-toggle="tooltip")
@@ -225,16 +224,16 @@ block content
 										div.summary-table-label Fee Rate
 										div.summary-table-content.text-monospace
 											if (result.getrawtransaction.vsize != result.getrawtransaction.size)
-												span #{utils.addThousandsSeparators(new DecimalRounded(totalInputValue).minus(totalOutputValue).dividedBy(result.getrawtransaction.vsize).times(100000000))} 
+												span #{utils.addThousandsSeparators(new DecimalRounded(feePaid).dividedBy(result.getrawtransaction.vsize).times(100000000))} 
 												small sat/vB
 												br
 
-												span.text-muted (#{utils.addThousandsSeparators(new DecimalRounded(totalInputValue).minus(totalOutputValue).dividedBy(result.getrawtransaction.size).times(100000000))} 
+												span.text-muted (#{utils.addThousandsSeparators(new DecimalRounded(feePaid).dividedBy(result.getrawtransaction.size).times(100000000))} 
 													small sat/B
 													span )
 
 											else
-												span #{utils.addThousandsSeparators(new DecimalRounded(totalInputValue).minus(totalOutputValue).dividedBy(result.getrawtransaction.size).times(100000000))} 
+												span #{utils.addThousandsSeparators(new DecimalRounded(feePaid).dividedBy(result.getrawtransaction.size).times(100000000))} 
 													small sat/B
 
 							- var daysDestroyed = new Decimal(0);


### PR DESCRIPTION
This is an attempt to enable as much of the functionality as possible for pruned nodes and for nodes without `txindex`.

`txindex` related changes:

  - Fetch block transactions with `getrawtransaction <txid> <blockhash>`. This works without `txindex`.
  - Tolerate missing previous output information and render transactions without it.
  - Support `/tx/<txid>?height=<height>` and link to it from block pages.

Pruning related changes:

  - Fallback to `getblockheader` instead of `getblock` for pruned blocks. The txid list and weight/size information will be missing.
  - Tolerate missing block stats.
  - Extract the Bitcoin whitepaper from the UTXO set.


Tested functionality:

- **Homepage:** Fully functional (recent blocks are unpruned, extracting the coinbase tx no longer depends on txindex)
- **Blocks list:** Functional except the "Avg Fee", "Fees" and "% Full" columns, which are unavailable for pruned blocks
- **Single block page:**
   Without txindex: Functional except not showing previous output information (address/amount) and the mining fee.
   With pruning: Shows only the summary for pruned blocks, without the tx list.
- **Single transaction page:** Only works for non-pruned txs, when the `height` query string parameter is specified. Does not show previous outputs info. **Edit:** Also works with wallet and recently confirmed transactions.
- **Mining Summary:** Works for recent unpruned blocks, shows (very) partial information for pruned blocks
- **Block Stats/Analysis:** Does not work for pruned blocks
- **Difficulty History:** Fully functional