### PR TITLE
Make event-loop-stats optional

### DIFF
--- a/app/systemMonitor.js
+++ b/app/systemMonitor.js
@@ -1,9 +1,14 @@
 const os = require("os");
 const v8 = require("v8");
 const pidusage = require("pidusage");
-const eventLoopStats = require("event-loop-stats");
 const statTracker = require("./statTracker.js");
+const debug = require("debug")("systemMonitor");
 
+try { var eventLoopStats = require("event-loop-stats"); }
+catch (err) {
+	debug("Failed loading event-loop-stats, skipping system monitor");
+	return;
+}
 
 const systemMonitorInterval = setInterval(() => {
 	pidusage(process.pid, (err, stat) => {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
 		"decimal.js": "^10.2.1",
 		"dotenv": "^8.2.0",
 		"electrum-client": "github:janoside/electrum-client",
-		"event-loop-stats": "^1.3.0",
 		"express": "^4.17.1",
 		"express-async-handler": "^1.1.4",
 		"express-session": "^1.17.1",
@@ -55,6 +54,9 @@
 		"semver": "^7.3.4",
 		"serve-favicon": "^2.5.0",
 		"simple-git": "^2.34.2"
+	},
+	"optionalDependencies": {
+		"event-loop-stats": "^1.3.0"
 	},
 	"devDependencies": {
 		"less": "3.9.0",


### PR DESCRIPTION
`event-loop-stats` is currently the only dependency that fails the installation if the native module cannot be built. The other native modules (tiny-secp256k1 and dtrace) make some noise when they fail, but let the installation continue and everything appears to work afterwards.

With this PR, it will be possible to install btc-rpc-explorer without an environment for building native modules (i.e. no need for `build-essential` and `python3`). This was possible before event-loop-stats was introduced.