### PR TITLE
API routes for ticker data use case

### DIFF
--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -50,6 +50,10 @@ function getBlockchainInfo() {
 	
 }
 
+function getBlockCount() {
+	return getRpcData("getblockcount");
+}
+
 function getNetworkInfo() {
 	return getRpcData("getnetworkinfo");
 }
@@ -572,6 +576,7 @@ module.exports = {
 	getRpcDataWithParams: getRpcDataWithParams,
 
 	getBlockchainInfo: getBlockchainInfo,
+	getBlockCount: getBlockCount,
 	getNetworkInfo: getNetworkInfo,
 	getNetTotals: getNetTotals,
 	getMempoolInfo: getMempoolInfo,

--- a/app/utils.js
+++ b/app/utils.js
@@ -282,7 +282,7 @@ function satoshisPerUnitOfLocalCurrency(localCurrency) {
 
 		var exchangedAmt = parseInt(dec);
 
-		return {amt:addThousandsSeparators(exchangedAmt), unit:`sat/${localCurrencyType.symbol}`}
+		return {amt:addThousandsSeparators(exchangedAmt),amtRaw:exchangedAmt, unit:`sat/${localCurrencyType.symbol}`}
 	}
 
 	return null;
@@ -326,7 +326,8 @@ function formatExchangedCurrency(amount, exchangeType) {
 		return {
 			val: addThousandsSeparators(exchangedAmt),
 			symbol: global.currencyTypes[exchangeType].symbol,
-			unit: exchangeType
+			unit: exchangeType,
+			valRaw: exchangedAmt
 		};
 	} else if (exchangeType == "au") {
 		if (global.exchangeRates != null && global.goldExchangeRates != null) {
@@ -337,7 +338,8 @@ function formatExchangedCurrency(amount, exchangeType) {
 			return {
 				val: addThousandsSeparators(exchangedAmt),
 				unit: "oz",
-				symbol: "AU"
+				symbol: "AU",
+				valRaw: exchangedAmt
 			};
 		}
 	}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,88 @@
+# API documentation
+
+## Blocks API
+### /api/v1/blocks/tip/height
+returns the height of the chain tip
+
+return type is numeric
+
+### /api/v1/blocks/tip/hash
+returns the block hash of the chain tip
+
+return type is numeric
+
+### /api/v1/blocks/totalbtc
+returns the current supply of Bitcoin (estimated on slow devices and before the UTXO set summary is loaded)
+
+return type is numeric
+
+### /api/v1/blocks/hashrate
+returns the network hash rate based on the last 7 days of blocks. Expressed in Exa-hashes.
+
+return type is json in this format
+
+`{"1Day":174.1,"7Days":165.9,"30Days":158.5}`
+
+### /api/v1/blocks/speed
+returns the difficulty adjustment percentage. The network is either increasing or decreasing in speed. Decrease in speed will be a negative number.
+
+return type is numeric
+
+
+## Mempool API
+### /api/v1/mempool/count
+returns the number of transactions in the mempool
+
+return type is numeric
+
+### /api/v1/mempool/fees/recommended
+returns fee rates in sats/vB for next block, next half an hour, next hour and next day as the minimum fee
+
+return type is json in this format 
+
+`{"fastestFee":17,"halfHourFee":9,"hourFee":9,"minimumFee":9}`
+
+
+## Price API
+### /api/v1/price/:currency
+request parameters: currency (usd, eur, gbp, xau)
+
+returns the price of 1 Bitcoin in USD, EUR, GBP, XAU
+
+return type is numeric
+
+### /api/v1/price/:currency/marketcap
+request parameters: currency (usd, eur, gbp, xau)
+
+returns the market cap of Bitcoin in USD, EUR, GBP, XAU
+
+return type is numeric
+
+### /api/v1/price/:currency/moscowtime
+request parameters: currency (usd, eur, gbp, xau)
+
+returns the price of 1 unit in local currency (eg $1) in satoshis
+
+return type is numeric
+
+
+## Transaction API
+### /raw-tx-with-inputs/:txid
+request parameters: txid 
+
+returns a json in this format
+
+`
+[{"transactions":
+  [{"in_active_chain":true,"txid":"7f49019b60ce2e8346160c71515a7c36509ced196b2d93ed5c866f284fa14942",
+    "hash":"bb758923c26952c535f5f48bc3efca932ed35e19aa4ec8dfcec9eb5a47476f94",
+    "version":2,"size":194,"vsize":113,"weight":449,"locktime":0,
+    "vin":[{"txid":"48cbc4d1c8092a76cbc2a9e07a65a08a491c86af082b7c9681693ef0e1397f53","vout":0,"scriptSig":{"asm":"","hex":""},
+    "txinwitness":["304402203da4ee26b825befec7d37389f8622da8275156d1f42f1bc9002e5faf3a837b0302203293ab5b6ad058a258b0ad0fb4cd1db152f1e832b4f19f041762372009fc62bd01","02e2c996310aa9e62d8495dff2b917030bdfbed529300b0b340ff3022564b23d28"],
+    "sequence":4294967295}],
+    "vout":[{"value":0.002535,"n":0,"scriptPubKey":{"asm":"OP_DUP OP_HASH160 6d118d674bee8e78a3522c5d884853af79660c0c OP_EQUALVERIFY OP_CHECKSIG","hex":"76a9146d118d674bee8e78a3522c5d884853af79660c0c88ac","reqSigs":1,
+    "type":"pubkeyhash","addresses":["1AwhgUBg7ew6jcCpiun5zJXDmJMqo38HBh"]}}],
+    "hex":"02000000000101537f39e1f03e6981967c2b08af861c498aa0657ae0a9c2cb762a09c8d1c4cb480000000000ffffffff013cde0300000000001976a9146d118d674bee8e78a3522c5d884853af79660c0c88ac0247304402203da4ee26b825befec7d37389f8622da8275156d1f42f1bc9002e5faf3a837b0302203293ab5b6ad058a258b0ad0fb4cd1db152f1e832b4f19f041762372009fc62bd012102e2c996310aa9e62d8495dff2b917030bdfbed529300b0b340ff3022564b23d2800000000",
+    "blockhash":"0000000000000000000d45158b5ba8363e724bbb9544e4ff827a9f076ac4703f",
+    "confirmations":1,"time":1620174086,"blocktime":1620174086}],"txInputsByTransaction":{}}]
+`

--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -21,6 +21,7 @@ const coins = require("./../app/coins.js");
 const config = require("./../app/config.js");
 const coreApi = require("./../app/api/coreApi.js");
 const addressApi = require("./../app/api/addressApi.js");
+const rpcApi = require("./../app/api/rpcApi.js");
 
 const forceCsrf = csurf({ ignoreMethods: [] });
 
@@ -364,6 +365,190 @@ router.get("/utils/:func/:params", function(req, res, next) {
 	next();
 });
 
+
+
+router.get("/v1/blocks/tip/height", function(req, res, next) {
+	rpcApi.getBlockCount().then(function(blockcount){
+		res.send(blockcount.toString());
+	}).catch(next);
+});
+
+router.get("/v1/blocks/tip/hash", function(req, res, next) {
+	coreApi.getBlockchainInfo().then(function(getblockchaininfo){
+		res.send(getblockchaininfo.bestblockhash.toString());
+	}).catch(next);
+});
+
+router.get("/v1/blocks/totalbtc", function(req, res, next) {	
+	if (global.utxoSetSummary) {
+		var supply = parseFloat(global.utxoSetSummary.total_amount).toString();
+		res.send(supply.toString());
+		next();
+	}
+	else {
+		// estimated supply
+		coreApi.getBlockchainInfo().then(function(getblockchaininfo){
+			var estimatedSupply = utils.estimatedSupply(getblockchaininfo.blocks);
+			res.send(estimatedSupply.toString());
+		}).catch(next);
+	}
+});
+
+router.get("/v1/blocks/hashrate", function(req, res, next) {
+	var blocksPerDay = 144;
+	var rates = [];
+	var timePeriods = [(1*blocksPerDay), (7*blocksPerDay), (30* blocksPerDay)];
+	
+	coreApi.getNetworkHashrate(timePeriods[0]).then(function(info0){
+		var hashRateData = utils.formatLargeNumber(info0, 1)
+		rates[0] = hashRateData[0];
+		
+		coreApi.getNetworkHashrate(timePeriods[1]).then(function(info1){
+			var hashRateData = utils.formatLargeNumber(info1, 1)
+			rates[1] = hashRateData[0];
+			
+			coreApi.getNetworkHashrate(timePeriods[2]).then(function(info2){
+				var hashRateData = utils.formatLargeNumber(info2, 1)
+				rates[2] = hashRateData[0];
+		
+				res.json({"1Day": rates[0]*1, "7Days": rates[1]*1, "30Days": rates[2]*1});
+			});
+		});
+	}).catch(next);
+});
+
+router.get("/v1/blocks/speed", asyncHandler(async (req, res, next) => {
+	var promises = [];
+	const getblockchaininfo = await utils.timePromise("promises.api.getBlockchainInfo", coreApi.getBlockchainInfo());
+	var currentBlock;
+	var difficultyPeriod = parseInt(Math.floor(getblockchaininfo.blocks / coinConfig.difficultyAdjustmentBlockCount));
+	var difficultyPeriodFirstBlockHeader;
+	
+	promises.push(new Promise(async (resolve, reject) => {
+			currentBlock = await utils.timePromise("promises.api.getBlockHeaderByHeight", coreApi.getBlockHeaderByHeight(getblockchaininfo.blocks));
+			resolve();
+	}));
+	
+	promises.push(new Promise(async (resolve, reject) => {
+			let h = coinConfig.difficultyAdjustmentBlockCount * difficultyPeriod;
+			difficultyPeriodFirstBlockHeader = await utils.timePromise("promises.api.getBlockHeaderByHeight", coreApi.getBlockHeaderByHeight(h));
+			resolve();
+	}));
+	
+	await Promise.all(promises);
+	
+	var firstBlockHeader = difficultyPeriodFirstBlockHeader;
+	var heightDiff = currentBlock.height - firstBlockHeader.height;
+	var timeDiff = currentBlock.mediantime - firstBlockHeader.mediantime;
+	var timePerBlock = timeDiff / heightDiff;	
+		
+	if (timePerBlock > 600) {
+			var diffAdjPercent = new Decimal(timeDiff / heightDiff / 600).times(100).minus(100);
+			diffAdjPercent = diffAdjPercent * -1;
+
+	} else {
+			var diffAdjPercent = new Decimal(100).minus(new Decimal(timeDiff / heightDiff / 600).times(100));
+	}	
+	
+	res.send(diffAdjPercent.toFixed(2).toString());
+}));
+
+router.get("/v1/mempool/count", function(req, res, next) {
+	coreApi.getMempoolInfo().then(function(info){
+		res.send(info.size.toString());
+	}).catch(next);
+});
+
+router.get("/v1/mempool/fees/recommended", function(req, res, next) {
+	var feeConfTargets = [1, 3, 6, 144];
+	coreApi.getSmartFeeEstimates("CONSERVATIVE", feeConfTargets).then(function(rawSmartFeeEstimates){
+		var smartFeeEstimates = {};
+		for (var i = 0; i < feeConfTargets.length; i++) {
+			var rawSmartFeeEstimate = rawSmartFeeEstimates[i];
+			if (rawSmartFeeEstimate.errors) {
+				smartFeeEstimates[feeConfTargets[i]] = "?";
+			} else {
+				smartFeeEstimates[feeConfTargets[i]] = parseInt(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000));
+			}
+		}		
+		
+		var results = {
+							"fastestFee":smartFeeEstimates[1],
+							"halfHourFee":smartFeeEstimates[3],
+							"hourFee":smartFeeEstimates[6],
+							"minimumFee":smartFeeEstimates[144]
+							};
+		res.json(results);
+	}).catch(next);
+});
+
+router.get("/v1/price/:currency/moscowtime", function(req, res, next) {
+	var result = 0;
+	var amount = 1.0;
+	var currency = req.params.currency.toLowerCase();
+	if (global.exchangeRates != null && global.exchangeRates[currency] != null) {
+		var satsRateData = utils.satoshisPerUnitOfLocalCurrency(currency);
+		result = satsRateData.amtRaw;
+	}
+	else if (currency == "xau" && global.exchangeRates != null && global.goldExchangeRates != null) {
+		var dec = new Decimal(amount);
+		dec = dec.times(global.exchangeRates.usd).dividedBy(global.goldExchangeRates.usd);
+		var satCurrencyType = global.currencyTypes["sat"];
+		var one = new Decimal(1);
+		dec = one.dividedBy(dec);
+		dec = dec.times(satCurrencyType.multiplier);
+		
+		result = dec.toFixed(0);
+	}
+	
+	res.send(result.toString());
+	next();
+});
+
+router.get("/v1/price/:currency/marketcap", function(req, res, next) {
+	var result = 0;
+	
+	coreApi.getBlockchainInfo().then(function(getblockchaininfo){
+		var estimatedSupply = utils.estimatedSupply(getblockchaininfo.blocks);
+		var price = 0;
+
+		var amount = 1.0;
+		var currency = req.params.currency.toLowerCase();
+		if (global.exchangeRates != null && global.exchangeRates[currency] != null) {
+			var formatData = utils.formatExchangedCurrency(amount, currency);
+			price = parseFloat(formatData.valRaw).toFixed(2);
+		}
+		else if (currency == "xau" && global.exchangeRates != null && global.goldExchangeRates != null) {
+			var dec = new Decimal(amount);
+			dec = dec.times(global.exchangeRates.usd).dividedBy(global.goldExchangeRates.usd);
+			var exchangedAmt = parseFloat(Math.round(dec * 100) / 100).toFixed(2);
+			price = exchangedAmt;
+		}
+	
+		result = estimatedSupply * price;
+		res.send(result.toFixed(2).toString());
+		next();
+	}).catch(next);
+});
+
+router.get("/v1/price/:currency", function(req, res, next) {
+	var result = 0;
+	var amount = 1.0;
+	var currency = req.params.currency.toLowerCase();
+	if (global.exchangeRates != null && global.exchangeRates[currency] != null) {
+		var formatData = utils.formatExchangedCurrency(amount, currency);
+		result = formatData.val;
+	}
+	else if (currency == "xau" && global.exchangeRates != null && global.goldExchangeRates != null) {
+		var dec = new Decimal(amount);
+		dec = dec.times(global.exchangeRates.usd).dividedBy(global.goldExchangeRates.usd);
+		var exchangedAmt = parseFloat(Math.round(dec * 100) / 100).toFixed(2);
+		result = utils.addThousandsSeparators(exchangedAmt);
+	}
+	
+	res.send(result.toString());
+	next();
+});
 
 
 module.exports = router;


### PR DESCRIPTION
I'd like to expose more data as a restful api as requested in issue https://github.com/janoside/btc-rpc-explorer/issues/55
Is this in scope?
I want to check if ApiRouter.js is the appropriate place for these new routes? 
Is there some naming conventions or json object structures I should copy? (Maybe https://mempool.space/api)

For some basic ticker data I have used 
https://blockchain.info/q/getblockcount
https://blockchain.info/q/unconfirmedcount
https://blockchain.info/q/hashrate
https://blockchain.info/q/totalbc
https://mempool.space/api/v1/fees/recommended

Those would represent an MVP for my uses to be able to query my own node instead of those third parties.

As a second phase I would want to support looking up information by address (balance, received tx, sent tx) and txid as I believe this would be useful to the wider community.
As a third phase I would want to support xpub/ypub/zpub because I have a project that consumes a third party paid API and I would like to migrate this to a more sovereign approach running on my own node.
