### PR TITLE
remove duplicate quotes

### DIFF
--- a/app/coins/btcQuotes.js
+++ b/app/coins/btcQuotes.js
@@ -216,22 +216,10 @@ module.exports = {
 			url: "https://www.metzdowd.com/pipermail/cryptography/2009-January/015014.html"
 		},
 		{
-			text: "I'm sure that in 20 years there will either be very large transaction volume or no volume.",
-			speaker: "Satoshi",
-			date: "2010-02-14",
-			url: "https://bitcointalk.org/index.php?topic=48.msg329#msg329"
-		},
-		{
 			text: "In a few decades when the reward gets too small, the transaction fee will become the main compensation for nodes.",
 			speaker: "Satoshi",
 			date: "2010-02-14",
 			url: "https://bitcointalk.org/index.php?topic=48.msg329#msg329"
-		},
-		{
-			text: "Lost coins only make everyone else's coins worth slightly more. Think of it as a donation to everyone.",
-			speaker: "Satoshi",
-			date: "2010-06-21",
-			url: "https://bitcointalk.org/index.php?topic=198.msg1647#msg1647"
 		},
 		{
 			text: "The utility of the exchanges made possible by Bitcoin will far exceed the cost of electricity used. Therefore, not having Bitcoin would be the net waste.",
@@ -444,6 +432,6 @@ module.exports = {
 			speaker: "https://twitter.com/LucDossis",
 			url: "https://twitter.com/btc_quotes/status/1410146340378644484?s=20"
 		},*/
-		
+
 	]
 };


### PR DESCRIPTION
Reading through the quotes, I noticed that a couple of them were duplicated:

> "I'm sure that in 20 years there will either be very large transaction volume or no volume."

Can be found on [line #219](https://github.com/janoside/btc-rpc-explorer/blob/master/app/coins/btcQuotes.js#L219) and [line #60](https://github.com/janoside/btc-rpc-explorer/blob/master/app/coins/btcQuotes.js#L60).

> "Lost coins only make everyone else's coins worth slightly more. Think of it as a donation to everyone."

Can be found on [line #231](https://github.com/janoside/btc-rpc-explorer/blob/master/app/coins/btcQuotes.js#L231) and [line #54](https://github.com/janoside/btc-rpc-explorer/blob/master/app/coins/btcQuotes.js#L54).

This PR removes the duplicates so that each quote appears only once.