### PR TITLE
fix: Job permissions for codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,8 +14,15 @@ on:
   schedule:
     - cron: '0 21 * * 4'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read # for github/codeql-action/init to get workflow details
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

[StepSecurity](https://github.com/step-security) is working on securing GitHub Actions and [OSSF Scorecards](https://github.com/ossf/scorecard) recommends using the StepSecurity [secure-workflows online tool](https://app.stepsecurity.io/) to improve the security of GitHub workflows.

This repository has a Scorecards score of 4.5/10 with 10 being the most secure. The Token-Permissions category has a score of 0/10. The link to the score is [here](https://deps.dev/npm/btc-rpc-explorer).

We have fixed this repo's workflow for you by adding permissions for the involved jobs. You can use StepSecurity [online tool](https://app.stepsecurity.io/) to secure workflows for your other repos.