### PR TITLE
Feature api 24 hour volume in BTC

### DIFF
--- a/CHANGELOG-API.md
+++ b/CHANGELOG-API.md
@@ -10,7 +10,7 @@ This changelog specifically tracks changes to the Public API available at `/api`
     * Added result.vin[i].scriptSig.type
     * Added result.fee, including result.fee.amount and result.fee.unit
 * Changed path: /api/util/xyzpub/:xyzpub -> /api/xyzpub/:xyzpub (auto-redirect included)
-
+* Added /api/txs/volume/24h
 
 
 ##### v1.1.0

--- a/docs/api.js
+++ b/docs/api.js
@@ -44,6 +44,14 @@ module.exports = {
 			"returnType":"json",
 			"testUrl": "/api/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16"
 		},
+		{
+			"category":"transactions",
+			"url":"/api/txs/volume/24h",
+			"desc":"Returns total output of all transactions over the last 24hrs.",
+			"returnType":"json",
+			"testUrl": "/api/txs/volume/24h"
+		},		
+		
 
 
 

--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -171,7 +171,22 @@ router.get("/tx/:txid", function(req, res, next) {
 	});
 });
 
-
+router.get("/txs/volume/24h", function(req, res, next) {
+	try {
+		if(networkVolume && networkVolume.d1 && networkVolume.d1.amt){
+			let currencyValue = parseInt(networkVolume.d1.amt)
+			res.json({"24h": currencyValue});	
+		}
+		else {
+			res.json({success:false, error: "Volume data not yet loaded."});		
+		}
+		next();	
+	}
+	catch (err) {
+		res.json({success:false, error:err});
+		next();
+	}
+});
 
 
 /// BLOCKCHAIN


### PR DESCRIPTION
With the recent market volatility I found it interesting to watch this metric, 24 hour volume in BTC, which is already available on the homepage of Bitcoin Explorer.

I have a ticker at home and want to display this metric using an API hence this pull request.

