### PR TITLE
dedupe quotes

### DIFF
--- a/app/coins/btcQuotes.js
+++ b/app/coins/btcQuotes.js
@@ -51,7 +51,7 @@ module.exports = {
 			url: "https://bitcointalk.org/index.php?topic=721.msg8114#msg8114"
 		},
 		{
-			text: "Lost coins only make everyone else's coins worth slightly more.  Think of it as a donation to everyone.",
+			text: "Lost coins only make everyone else's coins worth slightly more. Think of it as a donation to everyone.",
 			speaker: "Satoshi",
 			date: "2010-06-21",
 			url: "https://bitcointalk.org/index.php?topic=198.msg1647#msg1647"
@@ -216,22 +216,10 @@ module.exports = {
 			url: "https://www.metzdowd.com/pipermail/cryptography/2009-January/015014.html"
 		},
 		{
-			text: "I'm sure that in 20 years there will either be very large transaction volume or no volume.",
-			speaker: "Satoshi",
-			date: "2010-02-14",
-			url: "https://bitcointalk.org/index.php?topic=48.msg329#msg329"
-		},
-		{
 			text: "In a few decades when the reward gets too small, the transaction fee will become the main compensation for nodes.",
 			speaker: "Satoshi",
 			date: "2010-02-14",
 			url: "https://bitcointalk.org/index.php?topic=48.msg329#msg329"
-		},
-		{
-			text: "Lost coins only make everyone else's coins worth slightly more. Think of it as a donation to everyone.",
-			speaker: "Satoshi",
-			date: "2010-06-21",
-			url: "https://bitcointalk.org/index.php?topic=198.msg1647#msg1647"
 		},
 		{
 			text: "The utility of the exchanges made possible by Bitcoin will far exceed the cost of electricity used. Therefore, not having Bitcoin would be the net waste.",


### PR DESCRIPTION
The poor man's check in shell:

    $ grep "\stext:" app/coins/btcQuotes.js \
      | sort | sed 's/  / /' \
      | uniq -c | grep -v "\s1"
          2 			text: "I'm sure that in 20 years there will either be very large transaction volume or no volume.",
          2 			text: "Lost coins only make everyone else's coins worth slightly more. Think of it as a donation to everyone.",

Explanation: print out all the lines with an empty character followed by
"text:" (to not get "context:" for example). Then sort them all.
Change double space to one (there is this error in one of our duplicity
quotes). Count the unique lines. Filter out the lines which were found
only once. The result is the two duplicates before this patch, exactly
as reported in #455.