### PR TITLE
add block header API

### DIFF
--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -806,6 +806,12 @@ function getBlocksByHeight(blockHeights) {
 	});
 }
 
+function getBlockHeaderByHash(hash) {
+	return tryCacheThenRpcApi(blockCache, "getBlockHeaderByHash-" + hash, FIFTEEN_MIN, function() {
+		return rpcApi.getBlockHeaderByHash(hash);
+	});
+}
+
 function getBlockHeaderByHeight(blockHeight) {
 	return tryCacheThenRpcApi(blockCache, "getBlockHeaderByHeight-" + blockHeight, FIFTEEN_MIN, function() {
 		return rpcApi.getBlockHeaderByHeight(blockHeight);
@@ -2237,6 +2243,7 @@ module.exports = {
 	getBlockStatsByHeight: getBlockStatsByHeight,
 	getBlocksStatsByHeight: getBlocksStatsByHeight,
 	buildBlockAnalysisData: buildBlockAnalysisData,
+	getBlockHeaderByHash: getBlockHeaderByHash,
 	getBlockHeaderByHeight: getBlockHeaderByHeight,
 	getBlockHeadersByHeight: getBlockHeadersByHeight,
 	getTxOut: getTxOut,

--- a/docs/api.js
+++ b/docs/api.js
@@ -18,6 +18,22 @@ module.exports = {
 			"returnType":"json",
 			"testUrl":"/api/block/123456"
 		},
+		
+		{
+			"category":"blocks",
+			"url":"/api/blockheader/:hash",
+			"desc":"Returns the details of the block header with the given hash.",
+			"returnType":"json",
+			"testUrl":"/api/blockheader/0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893"
+		},
+
+		{
+			"category":"blocks",
+			"url":"/api/blockheader/:height",
+			"desc":"Returns the details of the block header at the given height.",
+			"returnType":"json",
+			"testUrl":"/api/blockheader/123456"
+		},
 
 		{
 			"category":"blocks",

--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -117,6 +117,29 @@ router.get("/block/:hashOrHeight", asyncHandler(async (req, res, next) => {
 	next();
 }));
 
+router.get("/blockheader/:hashOrHeight", asyncHandler(async (req, res, next) => {
+	const hashOrHeight = req.params.hashOrHeight;
+	let hash = (hashOrHeight.length == 64 ? hashOrHeight : null);
+
+	try {
+
+		if (hash == null) {
+			hash = await coreApi.getBlockHashByHeight(parseInt(hashOrHeight));
+		}
+
+		const block = await coreApi.getBlockHeaderByHash(hash);
+
+		res.json(block);
+
+	} catch (e) {
+		utils.logError("w8kwqpoauns", e);
+
+		res.json({success: false});
+	}
+
+	next();
+}));
+
 
 
 


### PR DESCRIPTION
As a consumer of the API I ran into the need for just the block header and not the whole block. 

Use case 1: showing a list of recent blocks on my site (and keep an archive).
Use case 2: call for the block header on the fly after consuming api/tx which returns block hash but not block height.