### PR TITLE
expose mempool size and total fees in api

### DIFF
--- a/docs/api.js
+++ b/docs/api.js
@@ -204,6 +204,13 @@ module.exports = {
 		},
 		{
 			"category":"mempool",
+			"url":"/api/mempool/info",
+			"desc":"Returns details on the active state of the TX memory pool in Bitcoin Core.",
+			"returnType":"json",
+			"example": {"loaded":true,"size":225,"bytes":76209,"usage":410496,"total_fee":0.01763495,"maxmempool":15000000,"mempoolminfee":0.00001,"minrelaytxfee":0.00001,"unbroadcastcount":0}
+		},
+		{
+			"category":"mempool",
 			"url":"/api/mempool/fees",
 			"desc":"Returns recommended fee rates in sats/vB for next block, ~30 min, 1 hr, and 1 day.",
 			"returnType":"json",

--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -17,9 +17,9 @@ const Decimal = require("decimal.js");
 const asyncHandler = require("express-async-handler");
 const markdown = require("markdown-it")();
 
-const utils = require('./../app/utils.js');
 const coins = require("./../app/coins.js");
 const config = require("./../app/config.js");
+const utils = require('./../app/utils.js');
 const coreApi = require("./../app/api/coreApi.js");
 const addressApi = require("./../app/api/addressApi.js");
 const xyzpubApi = require("./../app/api/xyzpubApi.js");
@@ -800,6 +800,12 @@ router.get("/mining/miner-summary", asyncHandler(async (req, res, next) => {
 router.get("/mempool/count", function(req, res, next) {
 	coreApi.getMempoolInfo().then(function(info){
 		res.send(info.size.toString());
+	}).catch(next);
+});
+
+router.get("/mempool/info", function(req, res, next) {
+	coreApi.getMempoolInfo().then(function(info){
+		res.json(info);
 	}).catch(next);
 });
 


### PR DESCRIPTION
Implementation of this feature request https://github.com/janoside/btc-rpc-explorer/issues/488

The Bitcoin Core getmempoolinfo is directly exposed via /mempool/info