### PR TITLE
Loop over getAddressDetails in /xyzpub handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ typings/
 cache/
 
 *.css.map
+
+# Visual Studio Code configuration files
+.vscode/

--- a/routes/baseRouter.js
+++ b/routes/baseRouter.js
@@ -803,7 +803,7 @@ router.get("/xyzpub/:extendedPubkey", asyncHandler(async (req, res, next) => {
 					if (Array.isArray(addressDetailsResult.errors) && addressDetailsResult.errors.length == 0) {
 						addressDetails.balanceSat += addressDetailsResult.addressDetails.balanceSat;
 						addressDetails.txCount += addressDetailsResult.addressDetails.txCount;
-						offset += addressDetails.txCount;
+						offset += addressDetailsResult.addressDetails.txCount;
 					}
 					else {
 						errors = true;


### PR DESCRIPTION
The aim is to get all transactions of an address

Note that I didn't test the case where the loop is executed twice. My test cases have only 0, 1 or 2 transactions. I tried lowering limit parameter to 1 but in this case getAddressDetails unexpectedly returns a count greater than the limit.

The `txCount == limit` condition terminates the loop when:
- there exist less transactions than wanted
- getAddressDetails returns more transactions than wanted

The latter is a correct termination in my test cases, but I am not sure this is generally true.

To secure the code the condition could be changed to `txCount > 0`, but this would double the number of getAddressDetails requests (with one useless call for each address).

Edit: I tried `txCount > 0` but I came across an infinite loop because getAddressDetails still returns data when passed an offset just after the last transactions, at least in my test case:
- address with only one transaction
- I call getAddressDetails with limit = 10 and offset = 1
- => it returns the transaction at offset 0.

With this problem + the fact that getAdresssDetails can return more transactions than limit value as mentioned above, it is difficult to find a sure solution.
