### PR TITLE
Improve keyboard accessibility (tabindex)

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -204,10 +204,10 @@ html(lang="en")
 
 							
 
-				form.form-inline.d-none.d-lg-inline(method="post", action="./search", style="width: 325px;")
+				form.form-inline.d-none.d-lg-inline(method="post", action="./search", style="width: 325px;", autocomplete="off")
 					input(type="hidden", name="_csrf", value=csrfToken)
 					.input-group
-						input.form-control(type="text", name="query", placeholder="block height/hash, txid, address", value=(query))
+						input.form-control(type="text", name="query", placeholder="block height/hash, txid, address", autocorrect="off", autocapitalize="off", tabindex="1")
 						
 						button.btn.btn-primary(type="submit", aria-label="Search")
 							i.bi-search

--- a/views/search.pug
+++ b/views/search.pug
@@ -7,11 +7,9 @@ block content
 	+pageTitle("Search")
 
 	+contentSection
-		form.form.form-inline(method="post", action="./search")
+		form.form.form-inline(method="post", action="./search", autocomplete="off")
 			input(type="hidden", name="_csrf", value=csrfToken)
 
 			div.input-group
-				input.form-control(type="text", name="query", placeholder="block height/hash, txid, address", value=(query), style="width: 400px;")
-				
+				input.form-control(type="text", name="query", placeholder="block height/hash, txid, address", tabindex="1", autocapitalize="off", autocorrect="off", style="width: 400px;")
 				button.btn.btn-primary(type="submit") Search
-		


### PR DESCRIPTION
Also disables autocomplete, autocapitalize and autocorrect on search textbox.

After Bitcoin Explorer is open, one only needs to press TAB once and enter what they search for.

This is not Auto-focus, which was also experimented with but moves whole view to the top on reload of something one may be watching, so I decided not to do any JavaScript auto-focus magic. Hopefully someone finds it useful, too.

This patch is alive at https://be.anyone.eu.org/