### PR TITLE
fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ##### v3.4.0
 ###### 2023-06-14
 
-* Breaking changes to the API (see [./api/changelog](/api/changlog))
+* Breaking changes to the API (see [./api/changelog](/api/changelog))
 * Homepage
 	* New "Next Halving" widget in Network Summary
 	* Show difficulty ATH comparison


### PR DESCRIPTION
Typo in internal link for API changelog