### PR TITLE
add P2P_V2 flag to servicename abbreviations

### DIFF
--- a/views/peers.pug
+++ b/views/peers.pug
@@ -135,7 +135,7 @@ block content
 								td
 									if (item.servicesnames)
 										- var serviceItems = item.servicesnames;
-										- var abbreviations = {"NETWORK":"NET", "NETWORK_LIMITED":"NET_LIM", "WITNESS":"WIT", "BLOOM":"BLM"};
+										- var abbreviations = {"NETWORK":"NET", "NETWORK_LIMITED":"NET_LIM", "WITNESS":"WIT", "BLOOM":"BLM", "P2P_V2":"P2P_V2"};
 
 										each itemAbbr, itemName in abbreviations
 											if (item.servicesnames.includes(itemName))


### PR DESCRIPTION
This pr adds the [BIP-324](https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki) service name to the abbreviations, so it shows up in the list.
