### PR TITLE
API: add nextBlock fees min, median, max

### DIFF
--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -867,32 +867,36 @@ router.get("/mempool/summary", function(req, res, next) {
 	}).catch(next);
 });
 
-router.get("/mempool/fees", function(req, res, next) {
-	let feeConfTargets = [1, 3, 6, 144];
-	coreApi.getSmartFeeEstimates("CONSERVATIVE", feeConfTargets).then(function(rawSmartFeeEstimates){
-		let smartFeeEstimates = {};
+router.get("/mempool/fees", asyncHandler(async (req, res, next) => {
+	let feeConfTargets = [1, 3, 6, 144];	
+	let rawSmartFeeEstimates = await coreApi.getSmartFeeEstimates("CONSERVATIVE", feeConfTargets);
+	let smartFeeEstimates = {};
+	
+	for (let i = 0; i < feeConfTargets.length; i++) {
+		let rawSmartFeeEstimate = rawSmartFeeEstimates[i];
+		if (rawSmartFeeEstimate.errors) {
+			smartFeeEstimates[feeConfTargets[i]] = "?";
+		} else {
+			smartFeeEstimates[feeConfTargets[i]] = parseInt(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000));
+		}
+	}		
 		
-		for (let i = 0; i < feeConfTargets.length; i++) {
-			let rawSmartFeeEstimate = rawSmartFeeEstimates[i];
-			if (rawSmartFeeEstimate.errors) {
-				smartFeeEstimates[feeConfTargets[i]] = "?";
+	let results = {
+		"nextBlock":smartFeeEstimates[1],
+		"30min":smartFeeEstimates[3],
+		"60min":smartFeeEstimates[6],
+		"1day":smartFeeEstimates[144]
+	};
 
-			} else {
-				smartFeeEstimates[feeConfTargets[i]] = parseInt(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000));
-			}
-		}		
-		
-		let results = {
-			"nextBlock":smartFeeEstimates[1],
-			"30min":smartFeeEstimates[3],
-			"60min":smartFeeEstimates[6],
-			"1day":smartFeeEstimates[144]
-		};
+	let nextBlockEstimate = await coreApi.getNextBlockEstimate();
+	if(nextBlockEstimate != undefined && nextBlockEstimate.minFeeRate != undefined) {
+		results.nextBlockMin = new Decimal(nextBlockEstimate.minFeeRate).toDP(0).toString();
+		results.nextBlockMax = new Decimal(nextBlockEstimate.maxFeeRate).toDP(0).toString();
+		results.nextBlockMedian = new Decimal(nextBlockEstimate.medianFeeRate).toDP(0).toString();
+	}
 
-		res.json(results);
-
-	}).catch(next);
-});
+	res.json(results);
+}));
 
 
 


### PR DESCRIPTION
We are in a high fee environment lately and I think it's useful to know the fees projected for the next block. Currently, the API is returning the fees from Core which has a long look-back and doesn't return a live value from the mempool.