### PR TITLE
fix confirmed block count for unconfirmed txns

### DIFF
--- a/views/includes/shared-mixins.pug
+++ b/views/includes/shared-mixins.pug
@@ -290,7 +290,7 @@ mixin txList(visibleTxs, txCount, limit, offset, inputsByTxid, options={})
 
 							if (options.showConfirmations)
 								+darkBadge
-									if (txBlockHeight)
+									if (txBlockHeight > -1)
 										span(title=`${(options.currentBlockHeight - txBlockHeight + 1).toLocaleString()} confirmation${(options.currentBlockHeight - txBlockHeight > 1) ? "s" :""}`, data-bs-toggle="tooltip")
 											i.bi-lock.me-1
 											- var confCount = options.currentBlockHeight - txBlockHeight + 1;


### PR DESCRIPTION
the check for unconfirmed transactions only checks if the `txBlockHeight` variable exists; since unconfirmed txns have a height of `-1`, it "exists", and the check passes. this pr checks `txBlockHeight > -1`.  
![before](https://github.com/janoside/btc-rpc-explorer/assets/33764485/c119d9da-c7aa-4f2c-988a-732794a69448)
![after](https://github.com/janoside/btc-rpc-explorer/assets/33764485/d758ba9c-9955-45ca-8381-5666ce98400c)

...dunno why the images wont load...