### PR TITLE
prioritize local configs over system-wide (and respect $XDG_CONFIG_HOME)

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,15 +20,17 @@ const debugErrorLog = debug("btcexp:error");
 const debugPerfLog = debug("btcexp:actionPerformace");
 const debugAccessLog = debug("btcexp:access");
 
+const xdgHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
 const configPaths = [
-	path.join(os.homedir(), ".config", "btc-rpc-explorer.env"),
-	path.join("/etc", "btc-rpc-explorer", ".env"),
 	path.join(process.cwd(), ".env"),
+	path.join(xdgHome, "btc-rpc-explorer.env"),
+	path.join(xdgHome, "btc-rpc-explorer", ".env"),
+	path.join("/etc", "btc-rpc-explorer", ".env"),
 ];
 
 debugLog("Searching for config files...");
 let configFileLoaded = false;
-configPaths.forEach(path => {
+for (const path of configPaths) {
 	if (fs.existsSync(path)) {
 		debugLog(`Config file found at ${path}, loading...`);
 
@@ -43,11 +45,11 @@ configPaths.forEach(path => {
 		}
 
 		configFileLoaded = true;
-
+		break
 	} else {
 		debugLog(`Config file not found at ${path}, continuing...`);
 	}
-});
+};
 
 if (!configFileLoaded) {
 	debugLog("No config files found. Using all defaults.");


### PR DESCRIPTION
this pr:
- changes the ordering of `configPaths` to list local paths before system,
- respects `XDG_CONFIG_HOME` if set,
- and stops loading configs upon successfully finding one, since dotenv doesnt overwrite
![early exit](https://github.com/janoside/btc-rpc-explorer/assets/33764485/cc1f42cc-de64-4320-88e6-b22b8e5a1458)

with `XDG_CONFIG_HOME=/var/tmp`
![image](https://github.com/janoside/btc-rpc-explorer/assets/33764485/6c121c22-a1ec-46ea-8124-39348a0b72c5)
