### PR TITLE
Adapted to bs58check V4 new interface

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -1331,11 +1331,11 @@ function xpubChangeVersionBytes(xpub, targetFormat) {
 	// trim whitespace
 	xpub = xpub.trim();
 
-	let data = bs58check.decode(xpub);
+	let data = bs58check.default.decode(xpub);
 	data = data.slice(4);
 	data = Buffer.concat([Buffer.from(xpubPrefixes.get(targetFormat), 'hex'), data]);
 
-	return bs58check.encode(data);
+	return bs58check.default.encode(data);
 }
 
 // HD wallet addresses

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2329,10 +2329,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-			"integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
-			"license": "MIT",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+			"integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",


### PR DESCRIPTION
This corrects extended public decoding which crashed with error: TypeError: bs58check.decode is not a function.

Regression can be tested with xpub6CpihtY9HVc1jNJWCiXnRbpXm5BgVNKqZMsM4XqpDcQigJr6AHNwaForLZ3kkisDcRoaXSUms6DJNhxFtQGeZfWAQWCZQe1esNetx5Wqe4M on public demo.

Additionally set version 1.7.4 for axios to correct vulnerability detected by npm audit