### PR TITLE
Dockerfile: update node.js to 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:16 as builder
+FROM node:20 as builder
 WORKDIR /workspace
 COPY . .
 RUN npm install
 
-FROM node:16-alpine
+FROM node:20-alpine
 WORKDIR /workspace
 COPY --from=builder /workspace .
 RUN apk --update add git


### PR DESCRIPTION
Updates node.js to the current active LTS version. Version 16 seems unmaintained at this time. See
https://nodejs.org/en/about/previous-releases

I tested this on my own server and I didn't notice any difference between running on node.js 16 and 20.