### PR TITLE
docker-compose.yml: remove obsolete version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
It's ignored by compose anyway. See
https://docs.docker.com/reference/compose-file/version-and-name/