### PR TITLE
Update btc.js

### DIFF
--- a/app/coins/btc.js
+++ b/app/coins/btc.js
@@ -551,8 +551,8 @@ module.exports = {
 		responseBodySelectorFunction:function(responseBody) {
 			//console.log("Exchange Rate Response: " + JSON.stringify(responseBody));
 
-			if (responseBody[0].topo && responseBody[0].topo.platform == "MT5") {
-				var prices = responseBody[0].spreadProfilePrices[0];
+			if (responseBody[7].topo && responseBody[7].topo.platform == "MT5") {
+				var prices = responseBody[7].spreadProfilePrices[0];
 				
 				return {
 					usd: prices.ask


### PR DESCRIPTION
Correction to the parsing of the JSON received from forex data URL. The order of the returned data appears to have changed. This fix only points to the correct data on the JSON data. The Gold exchange rate stopped working when the data received from the Forex URL changed format.