### PR TITLE
fix: display mempool fees < 1 sat/vB

### DIFF
--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -917,7 +917,7 @@ router.get("/mempool/fees", asyncHandler(async (req, res, next) => {
 		if (rawSmartFeeEstimate.errors) {
 			smartFeeEstimates[feeConfTargets[i]] = "?";
 		} else {
-			smartFeeEstimates[feeConfTargets[i]] = parseInt(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000));
+			smartFeeEstimates[feeConfTargets[i]] = parseFloat(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000).toPrecision(3));
 		}
 	}		
 		

--- a/routes/baseRouter.js
+++ b/routes/baseRouter.js
@@ -92,7 +92,7 @@ router.get("/", asyncHandler(async (req, res, next) => {
 					smartFeeEstimates[feeConfTargets[i]] = "?";
 
 				} else {
-					smartFeeEstimates[feeConfTargets[i]] = parseInt(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000));
+					smartFeeEstimates[feeConfTargets[i]] = parseFloat(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000).toPrecision(3));
 				}
 			}
 


### PR DESCRIPTION
formats mempool fees to 3 significant digits
<img width="736" height="168" alt="image" src="https://github.com/user-attachments/assets/51d893de-5ae2-4ffb-ad2d-f23bcec7bbfe" />

also does the same for the api:
```json
{
    "nextBlock": {/* trunc */},
    "30min": 2.72,
    "60min": 1.08,
    "1day": 0.741
}
```

"nextBlock" already handles decimals so its left unchanged